### PR TITLE
speex: fix config parsing

### DIFF
--- a/modules/speex/speex.c
+++ b/modules/speex/speex.c
@@ -442,9 +442,9 @@ static void config_parse(struct conf *conf)
 	if (0 == conf_get_u32(conf, "speex_enhancement", &v))
 		sconf.enhancement = v;
 	if (0 == conf_get_u32(conf, "speex_mode_nb", &v))
-		sconf.vbr = v;
+		sconf.mode_nb = v;
 	if (0 == conf_get_u32(conf, "speex_mode_wb", &v))
-		sconf.vbr = v;
+		sconf.mode_wb = v;
 	if (0 == conf_get_u32(conf, "speex_vbr", &v))
 		sconf.vbr = v;
 	if (0 == conf_get_u32(conf, "speex_vad", &v))


### PR DESCRIPTION
As noticed by @alfredh in pull request #41, I screwed up vbr settings by forgetting to fix actual variables when copy-pasting code.