### PR TITLE
gtk: don't run pkg-config on every operation

### DIFF
--- a/modules/gtk/module.mk
+++ b/modules/gtk/module.mk
@@ -8,8 +8,8 @@
 MOD		:= gtk
 $(MOD)_SRCS	+= gtk_mod.c call_window.c dial_dialog.c transfer_dialog.c \
 	uri_entry.c
-$(MOD)_LFLAGS      += `pkg-config --libs gtk+-2.0 $($(MOD)_EXTRA)`
-$(MOD)_CFLAGS      += `pkg-config --cflags gtk+-2.0 $($(MOD)_EXTRA)`
+$(MOD)_LFLAGS      != pkg-config --libs gtk+-2.0 $($(MOD)_EXTRA)
+$(MOD)_CFLAGS      != pkg-config --cflags gtk+-2.0 $($(MOD)_EXTRA)
 $(MOD)_CFLAGS	+= -Wno-strict-prototypes
 
 ifneq ($(USE_LIBNOTIFY),)


### PR DESCRIPTION
Thankfully GNU make has `!=` operator.