### PR TITLE
Get rid of VAR += `pkg-config ...` idiom

### DIFF
--- a/modules/directfb/module.mk
+++ b/modules/directfb/module.mk
@@ -7,7 +7,7 @@
 
 MOD                := directfb
 $(MOD)_SRCS        += directfb.c
-$(MOD)_LFLAGS      += `pkg-config --libs directfb `
-CFLAGS             += `pkg-config --cflags directfb `
+$(MOD)_LFLAGS      != pkg-config --libs directfb
+$(MOD)_CFLAGS      != pkg-config --cflags directfb
 
 include mk/mod.mk

--- a/modules/gst/module.mk
+++ b/modules/gst/module.mk
@@ -6,7 +6,7 @@
 
 MOD		:= gst
 $(MOD)_SRCS	+= gst.c dump.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-0.10`
-$(MOD)_CFLAGS	+= `pkg-config --cflags gstreamer-0.10`
+$(MOD)_LFLAGS	!= pkg-config --libs gstreamer-0.10
+$(MOD)_CFLAGS	!= pkg-config --cflags gstreamer-0.10
 
 include mk/mod.mk

--- a/modules/gst1/module.mk
+++ b/modules/gst1/module.mk
@@ -6,8 +6,8 @@
 
 MOD		:= gst1
 $(MOD)_SRCS	+= gst.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-1.0`
-$(MOD)_CFLAGS	+= `pkg-config --cflags gstreamer-1.0`
+$(MOD)_LFLAGS	!= pkg-config --libs gstreamer-1.0
+$(MOD)_CFLAGS	!= pkg-config --cflags gstreamer-1.0
 $(MOD)_CFLAGS	+= -Wno-cast-align
 
 include mk/mod.mk

--- a/modules/gst_video/module.mk
+++ b/modules/gst_video/module.mk
@@ -6,7 +6,7 @@
 
 MOD		:= gst_video
 $(MOD)_SRCS	+= gst_video.c h264.c encode.c sdp.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-0.10 gstreamer-app-0.10`
-$(MOD)_CFLAGS   += `pkg-config --cflags gstreamer-0.10 gstreamer-app-0.10`
+$(MOD)_LFLAGS	!= pkg-config --libs gstreamer-0.10 gstreamer-app-0.10
+$(MOD)_CFLAGS   != pkg-config --cflags gstreamer-0.10 gstreamer-app-0.10
 
 include mk/mod.mk

--- a/modules/gst_video1/module.mk
+++ b/modules/gst_video1/module.mk
@@ -6,8 +6,8 @@
 
 MOD		:= gst_video1
 $(MOD)_SRCS	+= gst_video.c h264.c encode.c sdp.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-1.0 gstreamer-app-1.0`
-$(MOD)_CFLAGS   += `pkg-config --cflags gstreamer-1.0 gstreamer-app-1.0`
+$(MOD)_LFLAGS	!= pkg-config --libs gstreamer-1.0 gstreamer-app-1.0
+$(MOD)_CFLAGS   != pkg-config --cflags gstreamer-1.0 gstreamer-app-1.0
 $(MOD)_CFLAGS	+= -Wno-cast-align
 
 include mk/mod.mk

--- a/modules/rst/module.mk
+++ b/modules/rst/module.mk
@@ -8,7 +8,7 @@ MOD		:= rst
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= rst.c
 $(MOD)_SRCS	+= video.c
-$(MOD)_LFLAGS	+= `pkg-config --libs cairo libmpg123`
-$(MOD)_CFLAGS	+= `pkg-config --cflags cairo libmpg123`
+$(MOD)_LFLAGS	!= pkg-config --libs cairo libmpg123
+$(MOD)_CFLAGS	!= pkg-config --cflags cairo libmpg123
 
 include mk/mod.mk


### PR DESCRIPTION
Output of `pkg-config` shouldn't change during build, so it is sufficient to run it once per check.

This pull request is follow-up to #80.