### PR TITLE
build infrastructure: get rid of " = `pkg-config ...`" idiom

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -100,16 +100,12 @@ USE_GSM := $(shell [ -f $(SYSROOT)/include/gsm.h ] || \
 	[ -f $(SYSROOT)/include/gsm/gsm.h ] || \
 	[ -f $(SYSROOT)/local/include/gsm.h ] || \
 	[ -f $(SYSROOT)/local/include/gsm/gsm.h ] && echo "yes")
-USE_GST := $(shell [ -f $(SYSROOT)/include/gstreamer-0.10/gst/gst.h ] || \
-	[ -f $(SYSROOT_ALT)/include/gstreamer-0.10/gst/gst.h ] && echo "yes")
-USE_GST1 := $(shell [ -f $(SYSROOT)/include/gstreamer-1.0/gst/gst.h ] || \
-	[ -f $(SYSROOT_ALT)/include/gstreamer-1.0/gst/gst.h ] && echo "yes")
-USE_GST_VIDEO := \
-	$(shell [ -f $(SYSROOT)/include/gstreamer-0.10/gst/gst.h ] || \
-	[ -f $(SYSROOT_ALT)/include/gstreamer-0.10/gst/gst.h ] && echo "yes")
-USE_GST_VIDEO1 := \
-	$(shell [ -f $(SYSROOT)/include/gstreamer-1.0/gst/gst.h ] || \
-	[ -f $(SYSROOT_ALT)/include/gstreamer-1.0/gst/gst.h ] && echo "yes")
+USE_GST := $(shell pkg-config --exists gstreamer-0.10 && echo "yes")
+USE_GST1 := $(shell pkg-config --exists gstreamer-1.0 && echo "yes")
+USE_GST_VIDEO := $(shell pkg-config --exists gstreamer-0.10 gstreamer-app-0.10 \
+		&& echo "yes")
+USE_GST_VIDEO1 := $(shell pkg-config --exists gstreamer-1.0 gstreamer-app-1.0 \
+		&& echo "yes")
 USE_ILBC := $(shell [ -f $(SYSROOT)/include/iLBC_define.h ] || \
 	[ -f $(SYSROOT)/local/include/iLBC_define.h ] && echo "yes")
 USE_ISAC := $(shell [ -f $(SYSROOT)/include/isac.h ] || \

--- a/modules/directfb/module.mk
+++ b/modules/directfb/module.mk
@@ -7,7 +7,7 @@
 
 MOD                := directfb
 $(MOD)_SRCS        += directfb.c
-$(MOD)_LFLAGS      += `pkg-config --libs directfb `
-CFLAGS             += `pkg-config --cflags directfb `
+$(MOD)_LFLAGS      += $(shell pkg-config --libs directfb)
+CFLAGS             += $(shell pkg-config --cflags directfb)
 
 include mk/mod.mk

--- a/modules/gst/module.mk
+++ b/modules/gst/module.mk
@@ -6,7 +6,7 @@
 
 MOD		:= gst
 $(MOD)_SRCS	+= gst.c dump.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-0.10`
-$(MOD)_CFLAGS	+= `pkg-config --cflags gstreamer-0.10`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gstreamer-0.10)
+$(MOD)_CFLAGS	+= $(shell pkg-config --cflags gstreamer-0.10)
 
 include mk/mod.mk

--- a/modules/gst1/module.mk
+++ b/modules/gst1/module.mk
@@ -6,8 +6,8 @@
 
 MOD		:= gst1
 $(MOD)_SRCS	+= gst.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-1.0`
-$(MOD)_CFLAGS	+= `pkg-config --cflags gstreamer-1.0`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gstreamer-1.0)
+$(MOD)_CFLAGS	+= $(shell pkg-config --cflags gstreamer-1.0)
 $(MOD)_CFLAGS	+= -Wno-cast-align
 
 include mk/mod.mk

--- a/modules/gst_video/module.mk
+++ b/modules/gst_video/module.mk
@@ -6,7 +6,7 @@
 
 MOD		:= gst_video
 $(MOD)_SRCS	+= gst_video.c h264.c encode.c sdp.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-0.10 gstreamer-app-0.10`
-$(MOD)_CFLAGS   += `pkg-config --cflags gstreamer-0.10 gstreamer-app-0.10`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gstreamer-0.10 gstreamer-app-0.10)
+$(MOD)_CFLAGS   += $(shell pkg-config --cflags gstreamer-0.10 gstreamer-app-0.10)
 
 include mk/mod.mk

--- a/modules/gst_video1/module.mk
+++ b/modules/gst_video1/module.mk
@@ -6,8 +6,8 @@
 
 MOD		:= gst_video1
 $(MOD)_SRCS	+= gst_video.c h264.c encode.c sdp.c
-$(MOD)_LFLAGS	+= `pkg-config --libs gstreamer-1.0 gstreamer-app-1.0`
-$(MOD)_CFLAGS   += `pkg-config --cflags gstreamer-1.0 gstreamer-app-1.0`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gstreamer-1.0 gstreamer-app-1.0)
+$(MOD)_CFLAGS   += $(shell pkg-config --cflags gstreamer-1.0 gstreamer-app-1.0)
 $(MOD)_CFLAGS	+= -Wno-cast-align
 
 include mk/mod.mk

--- a/modules/gtk/module.mk
+++ b/modules/gtk/module.mk
@@ -8,13 +8,13 @@
 MOD		:= gtk
 $(MOD)_SRCS	+= gtk_mod.c call_window.c dial_dialog.c transfer_dialog.c \
 	uri_entry.c
-$(MOD)_LFLAGS      += `pkg-config --libs gtk+-2.0 $($(MOD)_EXTRA)`
-$(MOD)_CFLAGS      += `pkg-config --cflags gtk+-2.0 $($(MOD)_EXTRA)`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gtk+-2.0 $($(MOD)_EXTRA))
+$(MOD)_CFLAGS	+= $(shell pkg-config --cflags gtk+-2.0 $($(MOD)_EXTRA))
 $(MOD)_CFLAGS	+= -Wno-strict-prototypes
 
 ifneq ($(USE_LIBNOTIFY),)
-$(MOD)_EXTRA = libnotify
-$(MOD)_CFLAGS += -DUSE_LIBNOTIFY=1
+$(MOD)_EXTRA	 = libnotify
+$(MOD)_CFLAGS	+= -DUSE_LIBNOTIFY=1
 endif
 
 include mk/mod.mk

--- a/modules/rst/module.mk
+++ b/modules/rst/module.mk
@@ -8,7 +8,7 @@ MOD		:= rst
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= rst.c
 $(MOD)_SRCS	+= video.c
-$(MOD)_LFLAGS	+= `pkg-config --libs cairo libmpg123`
-$(MOD)_CFLAGS	+= `pkg-config --cflags cairo libmpg123`
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs cairo libmpg123)
+$(MOD)_CFLAGS	+= $(shell pkg-config --cflags cairo libmpg123)
 
 include mk/mod.mk


### PR DESCRIPTION
Followup to #80 and #81. This time using `shell` macro.