### PR TITLE
daala: recover after recent api change

### DIFF
--- a/modules/daala/decode.c
+++ b/modules/daala/decode.c
@@ -150,9 +150,15 @@ int daala_decode(struct viddec_state *vds, struct vidframe *frame,
 			return EPROTO;
 		}
 
-		r = daala_decode_packet_in(vds->dec, &img, &dp);
+		r = daala_decode_packet_in(vds->dec, &dp);
 		if (r < 0) {
 			warning("daala: decode: packet_in error (%d)\n", r);
+			return EPROTO;
+		}
+
+		r = daala_decode_img_out(vds->dec, &img);
+		if (r != 1) {
+			warning("daala: decode: img_out error (%d)\n", r);
 			return EPROTO;
 		}
 


### PR DESCRIPTION
Commit [dd604a08](https://github.com/xiph/daala/commit/dd604a08694fa70b28b0f0888a83dede78c1ee90) to daala split `daala_decode_packet_in()` into `daala_decode_packet_in()` and `daala_decode_img_out()`. This diff is supposed to adapt *daala* module to this change.