### PR TITLE
sndio: test whether par was allocated before freeing it

### DIFF
--- a/modules/sndio/sndio.c
+++ b/modules/sndio/sndio.c
@@ -268,7 +268,9 @@ static int play_alloc(struct auplay_st **stp, const struct auplay *ap,
 		st->run = false;
 
  out:
-	mem_deref(par);
+	if (par)
+		mem_deref(par);
+
 	if (err)
 		mem_deref(st);
 	else


### PR DESCRIPTION
I hit this bug when `sndiod` didn't start after system update, and my hardware rejected requested parameters. Most users should never need it, and this is not really a fix to the real issue, but IMO if someone tries baresip without `sndiod` on unfortunate hardware, it is better to report failure then to dump core.