### PR TITLE
aucodec: split srate into srate and crate (Clock Rate)

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -737,7 +737,8 @@ struct aucodec {
 	struct le le;
 	const char *pt;
 	const char *name;
-	uint32_t srate;
+	uint32_t srate;             /* Audio samplerate */
+	uint32_t crate;             /* RTP Clock rate   */
 	uint8_t ch;
 	const char *fmtp;
 	auenc_update_h *encupdh;

--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -292,7 +292,7 @@ static int decode_nb(struct audec_state *st, int16_t *sampv,
 
 #ifdef AMR_WB
 static struct aucodec amr_wb = {
-	LE_INIT, NULL, "AMR-WB", 16000, 1, NULL,
+	LE_INIT, NULL, "AMR-WB", 16000, 16000, 1, NULL,
 	encode_update, encode_wb,
 	decode_update, decode_wb,
 	NULL, amr_fmtp_enc, amr_fmtp_cmp
@@ -300,7 +300,7 @@ static struct aucodec amr_wb = {
 #endif
 #ifdef AMR_NB
 static struct aucodec amr_nb = {
-	LE_INIT, NULL, "AMR", 8000, 1, NULL,
+	LE_INIT, NULL, "AMR", 8000, 8000, 1, NULL,
 	encode_update, encode_nb,
 	decode_update, decode_nb,
 	NULL, amr_fmtp_enc, amr_fmtp_cmp

--- a/modules/bv32/bv32.c
+++ b/modules/bv32/bv32.c
@@ -151,7 +151,7 @@ static int plc(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 
 static struct aucodec bv32 = {
-	LE_INIT, 0, "BV32", 16000, 1, NULL,
+	LE_INIT, 0, "BV32", 16000, 16000, 1, NULL,
 	encode_update, encode,
 	decode_update, decode, plc,
 	NULL, NULL

--- a/modules/codec2/codec2.c
+++ b/modules/codec2/codec2.c
@@ -165,6 +165,7 @@ static struct aucodec codec2 = {
 	NULL,
 	"CODEC2",
 	8000,
+	8000,
 	1,
 	NULL,
 	encode_update,

--- a/modules/g711/g711.c
+++ b/modules/g711/g711.c
@@ -97,12 +97,12 @@ static int pcma_decode(struct audec_state *ads, int16_t *sampv,
 
 
 static struct aucodec pcmu = {
-	LE_INIT, "0", "PCMU", 8000, 1, NULL,
+	LE_INIT, "0", "PCMU", 8000, 8000, 1, NULL,
 	NULL, pcmu_encode, NULL, pcmu_decode, NULL, NULL, NULL
 };
 
 static struct aucodec pcma = {
-	LE_INIT, "8", "PCMA", 8000, 1, NULL,
+	LE_INIT, "8", "PCMA", 8000, 8000, 1, NULL,
 	NULL, pcma_encode, NULL, pcma_decode, NULL, NULL, NULL
 };
 

--- a/modules/g722/g722.c
+++ b/modules/g722/g722.c
@@ -162,7 +162,7 @@ static int decode(struct audec_state *st, int16_t *sampv, size_t *sampc,
 
 
 static struct aucodec g722 = {
-	LE_INIT, "9", "G722", 8000, 1, NULL,
+	LE_INIT, "9", "G722", 16000, 8000, 1, NULL,
 	encode_update, encode,
 	decode_update, decode, NULL,
 	NULL, NULL

--- a/modules/g7221/g7221.c
+++ b/modules/g7221/g7221.c
@@ -13,6 +13,7 @@ static struct g7221_aucodec g7221 = {
 	.ac = {
 		.name      = "G7221",
 		.srate     = 16000,
+		.crate     = 16000,
 		.ch        = 1,
 		.encupdh   = g7221_encode_update,
 		.ench      = g7221_encode,

--- a/modules/g726/g726.c
+++ b/modules/g726/g726.c
@@ -149,28 +149,28 @@ static int decode(struct audec_state *st, int16_t *sampv,
 static struct g726_aucodec g726[4] = {
 	{
 		{
-			LE_INIT, 0, "G726-40", 8000, 1, NULL,
+			LE_INIT, 0, "G726-40", 8000, 8000, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		40000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-32", 8000, 1, NULL,
+			LE_INIT, 0, "G726-32", 8000, 8000, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		32000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-24", 8000, 1, NULL,
+			LE_INIT, 0, "G726-24", 8000, 8000, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		24000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-16", 8000, 1, NULL,
+			LE_INIT, 0, "G726-16", 8000, 8000, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		16000

--- a/modules/gsm/gsm.c
+++ b/modules/gsm/gsm.c
@@ -149,7 +149,7 @@ static int decode(struct audec_state *st, int16_t *sampv, size_t *sampc,
 
 
 static struct aucodec ac_gsm = {
-	LE_INIT, "3", "GSM", 8000, 1, NULL,
+	LE_INIT, "3", "GSM", 8000, 8000, 1, NULL,
 	encode_update, encode, decode_update, decode, NULL, NULL, NULL
 };
 

--- a/modules/ilbc/ilbc.c
+++ b/modules/ilbc/ilbc.c
@@ -327,7 +327,7 @@ static int pkloss(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 
 static struct aucodec ilbc = {
-	LE_INIT, 0, "iLBC", 8000, 1, ilbc_fmtp,
+	LE_INIT, 0, "iLBC", 8000, 8000, 1, ilbc_fmtp,
 	encode_update, encode, decode_update, decode, pkloss, 0, 0
 };
 

--- a/modules/isac/isac.c
+++ b/modules/isac/isac.c
@@ -186,11 +186,11 @@ static int plc(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 static struct aucodec isacv[] = {
 	{
-	LE_INIT, 0, "isac", 32000, 1, NULL,
+	LE_INIT, 0, "isac", 32000, 32000, 1, NULL,
 	encode_update, encode, decode_update, decode, plc, NULL, NULL
 	},
 	{
-	LE_INIT, 0, "isac", 16000, 1, NULL,
+	LE_INIT, 0, "isac", 16000, 16000, 1, NULL,
 	encode_update, encode, decode_update, decode, plc, NULL, NULL
 	}
 };

--- a/modules/l16/l16.c
+++ b/modules/l16/l16.c
@@ -62,14 +62,14 @@ static int decode(struct audec_state *st, int16_t *sampv, size_t *sampc,
 
 /* See RFC 3551 */
 static struct aucodec l16v[NR_CODECS] = {
-	{LE_INIT, "10", "L16", 44100, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16", 32000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16", 16000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16",  8000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT, "11", "L16", 44100, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16", 32000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16", 16000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-	{LE_INIT,    0, "L16",  8000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT, "10", "L16", 44100, 44100, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 32000, 32000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 16000, 16000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16",  8000,  8000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT, "11", "L16", 44100, 44100, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 32000, 32000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 16000, 16000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16",  8000,  8000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
 };
 
 

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -82,7 +82,8 @@ static struct aucodec mpa = {
 	.pt       = NULL,	/* for the time being, to cope
 with AVT AC1 interop problems, we do not use "14" here */
 	.name      = "MPA",
-	.srate     = 90000,
+	.srate     = 48000,
+	.crate     = 90000,
 	.ch       = 1,
 	.fmtp      = "",
 	.encupdh   = mpa_encode_update,

--- a/modules/opus/opus.c
+++ b/modules/opus/opus.c
@@ -29,6 +29,7 @@
 static struct aucodec opus = {
 	.name      = "opus",
 	.srate     = 48000,
+	.crate     = 48000,
 	.ch        = 2,
 	.fmtp      = "stereo=1;sprop-stereo=1",
 	.encupdh   = opus_encode_update,

--- a/modules/silk/silk.c
+++ b/modules/silk/silk.c
@@ -226,7 +226,7 @@ static int plc(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 static struct aucodec silk[] = {
 	{
-		LE_INIT, 0, "SILK", 24000, 1, NULL,
+		LE_INIT, 0, "SILK", 24000, 24000, 1, NULL,
 		encode_update, encode, decode_update, decode, plc, 0, 0
 	},
 

--- a/modules/speex/speex.c
+++ b/modules/speex/speex.c
@@ -462,19 +462,19 @@ static void config_parse(struct conf *conf)
 static struct aucodec speexv[] = {
 
 	/* Stereo Speex */
-	{LE_INIT, 0, "speex", 32000, 2, speex_fmtp_wb,
+	{LE_INIT, 0, "speex", 32000, 32000, 2, speex_fmtp_wb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
-	{LE_INIT, 0, "speex", 16000, 2, speex_fmtp_wb,
+	{LE_INIT, 0, "speex", 16000, 16000, 2, speex_fmtp_wb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
-	{LE_INIT, 0, "speex",  8000, 2, speex_fmtp_nb,
+	{LE_INIT, 0, "speex",  8000,  8000, 2, speex_fmtp_nb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
 
 	/* Standard Speex */
-	{LE_INIT, 0, "speex", 32000, 1, speex_fmtp_wb,
+	{LE_INIT, 0, "speex", 32000, 32000, 1, speex_fmtp_wb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
-	{LE_INIT, 0, "speex", 16000, 1, speex_fmtp_wb,
+	{LE_INIT, 0, "speex", 16000, 16000, 1, speex_fmtp_wb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
-	{LE_INIT, 0, "speex",  8000, 1, speex_fmtp_nb,
+	{LE_INIT, 0, "speex",  8000,  8000, 1, speex_fmtp_nb,
 	 encode_update, encode, decode_update, decode, pkloss, 0, 0},
 };
 

--- a/test/call.c
+++ b/test/call.c
@@ -88,6 +88,7 @@ static struct aucodec dummy_pcma = {
 	.pt = "8",
 	.name = "PCMA",
 	.srate = 8000,
+	.crate = 8000,
 	.ch = 1,
 };
 


### PR DESCRIPTION
All, @choene please review and test this patch.

The patch splits the "srate" parameter of struct aucodec into 2 parts; srate and crate.
The srate is the Audio sample-rate for the DSP, the crate is the RTP Clock rate.

Most audio codecs will use exactly the same value here. The exception is e.g G.722 and MPA.
For example G.722 has 8000 Hz and 16000 Hz:

https://tools.ietf.org/html/rfc3551#section-4.5.2

```
   Even though the actual sampling rate for G.722 audio is 16,000 Hz,
   the RTP clock rate for the G722 payload format is 8,000 Hz because
   that value was erroneously assigned in RFC 1890 and must remain
   unchanged for backward compatibility.  The octet rate or sample-pair
   rate is 8,000 Hz.
```

the goal is to make audio.c agnostic to these codec details.
