### PR TITLE
Build gtk module only with new enough glib

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -200,9 +200,7 @@ USE_VPX  := $(shell [ -f $(SYSROOT)/include/vpx/vp8.h ] \
 	|| [ -f $(SYSROOT)/local/include/vpx/vp8.h ] \
 	|| [ -f $(SYSROOT_ALT)/include/vpx/vp8.h ] \
 	&& echo "yes")
-USE_GTK := $(shell [ -f $(SYSROOT)/include/gtk-2.0/gtk/gtk.h ] || \
-	[ -f $(SYSROOT)/local/include/gtk-2.0/gtk/gtk.h ] || \
-	[ -f $(SYSROOT_ALT)/include/gtk-2.0/gtk/gtk.h ] && echo "yes")
+USE_GTK := $(shell pkg-config 'glib-2.0 >= 2.32' && echo "yes")
 else
 # Windows.
 # Accounts for mingw with Windows SDK (formerly known as Platform SDK)


### PR DESCRIPTION
GLib 2.32 is needed for some things: https://developer.gnome.org/gio/stable/api-index-2-32.html

#122 