### PR TITLE
Fixing some issues with the MPA codec

### DIFF
--- a/modules/mpa/decode.c
+++ b/modules/mpa/decode.c
@@ -24,7 +24,7 @@ static void destructor(void *arg)
 {
 	struct audec_state *ads = arg;
 
-	if(ads->resampler)
+	if (ads->resampler)
 		speex_resampler_destroy(ads->resampler);
 
 	mpg123_close(ads->dec);
@@ -73,7 +73,7 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 #else
 	result = mpg123_param(ads->dec, MPG123_VERBOSE, 0, 0.);
 #endif
-	if ( result != MPG123_OK) {
+	if (result != MPG123_OK) {
 		error("MPA dec param error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
@@ -82,7 +82,7 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 
 
 	result = mpg123_format_all(ads->dec);
-	if ( result != MPG123_OK) {
+	if (result != MPG123_OK) {
 		error("MPA dec format error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
@@ -90,7 +90,7 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 	}
 
 	result = mpg123_open_feed(ads->dec);
-	if ( result != MPG123_OK) {
+	if (result != MPG123_OK) {
 		error("MPA dec open feed error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
@@ -124,7 +124,7 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 	if (!ads || !sampv || !sampc || !buf || len<=4)
 		return EINVAL;
 
-	if(*(uint32_t*)buf != 0) {
+	if (*(uint32_t*)buf != 0) {
 		error("MPA dec header is not zero %08X, not supported yet\n",
 			*(uint32_t*)buf);
 		return EPROTO;
@@ -148,7 +148,7 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 
 		ads->channels = channels;
 		ads->start = 0;
-		if(ads->resampler)
+		if (ads->resampler)
 			speex_resampler_destroy(ads->resampler);
 		if (samplerate != 48000) {
 			ads->resampler = speex_resampler_init(channels,

--- a/modules/mpa/decode.c
+++ b/modules/mpa/decode.c
@@ -108,7 +108,7 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 		    const uint8_t *buf, size_t len)
 {
-	int result, channels, encoding, i;
+	int result, channels, encoding, i, result2;
 	long samplerate;
 	size_t n;
 	spx_uint32_t intermediate_len;
@@ -131,10 +131,10 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 		intermediate_len = n / 2 / ads->channels;
 			/* intermediate_len counts samples per channel */
 		out_len = *sampc;
-		result=speex_resampler_process_interleaved_int(
+		result2=speex_resampler_process_interleaved_int(
 			ads->resampler, ads->intermediate_buffer,
 			&intermediate_len, sampv, &out_len);
-		if (result!=RESAMPLER_ERR_SUCCESS) {
+		if (result2!=RESAMPLER_ERR_SUCCESS) {
 			error("mpa: upsample error: %s %d %d\n",
 				strerror(result), out_len, *sampc/2);
 			return EPROTO;

--- a/modules/mpa/decode.c
+++ b/modules/mpa/decode.c
@@ -30,7 +30,7 @@ static void destructor(void *arg)
 	mpg123_close(ads->dec);
 	mpg123_delete(ads->dec);
 #ifdef DEBUG
-	debug("mpa: decoder destroyed\n");
+	debug("MPA dec destroyed\n");
 #endif
 }
 
@@ -47,7 +47,7 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 	ads = *adsp;
 
 #ifdef DEBUG
-	debug("mpa: decoder created %s\n",fmtp);
+	debug("MPA dec created %s\n",fmtp);
 #endif
 
 	if (ads)
@@ -73,8 +73,8 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 #else
 	result = mpg123_param(ads->dec, MPG123_VERBOSE, 0, 0.);
 #endif
-	if (result != MPG123_OK) {
-		error("MPA libmpg123 param error %s\n",
+	if ( result != MPG123_OK) {
+		error("MPA dec param error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
 		goto out;
@@ -82,16 +82,16 @@ int mpa_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 
 
 	result = mpg123_format_all(ads->dec);
-	if (result != MPG123_OK) {
-		error("MPA libmpg123 format error %s\n",
+	if ( result != MPG123_OK) {
+		error("MPA dec format error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
 		goto out;
 	}
 
 	result = mpg123_open_feed(ads->dec);
-	if (result != MPG123_OK) {
-		error("MPA libmpg123 open feed error %s\n",
+	if ( result != MPG123_OK) {
+		error("MPA dec open feed error %s\n",
 			mpg123_plain_strerror(result));
 		err = EINVAL;
 		goto out;
@@ -118,32 +118,32 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 	spx_uint32_t out_len;
 
 #ifdef DEBUG
-		info("mpa decode start %d %ld\n",len, *sampc);
+	debug("MPA dec start %d %ld\n",len, *sampc);
 #endif
 
 	if (!ads || !sampv || !sampc || !buf || len<=4)
 		return EINVAL;
 
 	if(*(uint32_t*)buf != 0) {
-		error("MPA header is not zero %08X, not supported yet\n",
+		error("MPA dec header is not zero %08X, not supported yet\n",
 			*(uint32_t*)buf);
 		return EPROTO;
 	}
 
-		n = 0;
-		result = mpg123_decode(ads->dec, buf+4, len-4,
+	n = 0;
+	result = mpg123_decode(ads->dec, buf+4, len-4,
 				(unsigned char*)ads->intermediate_buffer,
 				sizeof(ads->intermediate_buffer), &n);
 				/* n counts bytes */
 
 #ifdef DEBUG
-		info("mpa decoded %d %d %d %d\n",result, len-4, n, ads->channels);
+	debug("MPA dec %d %d %d %d\n",result, len-4, n, ads->channels);
 #endif
 
 
 	if (result == MPG123_NEW_FORMAT) {
 		mpg123_getformat(ads->dec, &samplerate, &channels, &encoding);
-		info("MPA libmpg123 format change %d %d %04X\n",samplerate
+		info("MPA dec format change %d %d %04X\n",samplerate
 			,channels,encoding);
 
 		ads->channels = channels;
@@ -155,17 +155,17 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 				samplerate, 48000, 3, &result);
 			if (result!=RESAMPLER_ERR_SUCCESS
 				|| ads->resampler==NULL) {
-				error("mpa: upsampler failed %d\n",result);
+				error("MPA dec upsampler failed %d\n",result);
 				return EINVAL;
 			}
 		}
 		else
 			ads->resampler = NULL;
 	}
-	else if (result == MPG123_NEED_MORE) ;
-//		return 0;
+	else if (result == MPG123_NEED_MORE) 
+		;			/* workaround: do nothing */ 
 	else if (result != MPG123_OK) {
-		error("MPA libmpg123 feed error %d %s\n", result,
+		error("MPA dec feed error %d %s\n", result,
 			mpg123_plain_strerror(result));
 		return EPROTO;
 	}
@@ -179,7 +179,7 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 			ads->resampler, ads->intermediate_buffer,
 			&intermediate_len, sampv, &out_len);
 		if (result!=RESAMPLER_ERR_SUCCESS) {
-			error("mpa: upsample error: %s %d %d\n",
+			error("MPA dec upsample error: %s %d %d\n",
 				strerror(result), out_len, *sampc/2);
 			return EPROTO;
 		}
@@ -205,7 +205,7 @@ int mpa_decode_frm(struct audec_state *ads, int16_t *sampv, size_t *sampc,
 	}
 
 #ifdef DEBUG
-	info("mpa decode done %d\n",*sampc);
+	debug("MPA dec done %d\n",*sampc);
 #endif
 	}
 

--- a/modules/mpa/encode.c
+++ b/modules/mpa/encode.c
@@ -31,7 +31,7 @@ static void destructor(void *arg)
 	if (aes->enc)
 		twolame_close(&aes->enc);
 #ifdef DEBUG
-	info("mpa encode destroyed\n");
+	debug("MPA enc destroyed\n");
 #endif
 }
 
@@ -55,13 +55,13 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	aes = mem_zalloc(sizeof(*aes), destructor);
 	aes->enc = twolame_init();
 	if (!aes->enc) {
-		error("mpa: encoder create failed\n");
+		error("MPA enc create failed\n");
 		mem_deref(aes);
 		return ENOMEM;
 	}
 	aes->channels = ac->ch;
 #ifdef DEBUG
-	info("mpa: encoder created %s\n",fmtp);
+	debug("MPA enc created %s\n",fmtp);
 #endif
 
 	prm.samplerate = 32000;
@@ -89,14 +89,14 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	result |= twolame_set_out_samplerate(aes->enc, prm.samplerate);
 	result |= twolame_set_num_channels(aes->enc, 2);
 	if (result!=0) {
-		error("mpa: encoder set failed\n");
+		error("MPA enc set failed\n");
 		err=EINVAL;
 		goto out;
 	}
 
 	result = twolame_init_params(aes->enc);
 	if (result!=0) {
-		error("mpa: encoder init params failed\n");
+		error("MPA enc init params failed\n");
 		err=EINVAL;
 		goto out;
 	}
@@ -107,7 +107,7 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 		aes->resampler = speex_resampler_init(2, 48000,
 			prm.samplerate, 3, &result);
 		if (result!=RESAMPLER_ERR_SUCCESS) {
-			error("mpa: resampler init failed %d\n",result);
+			error("MPA enc resampler init failed %d\n",result);
 			err=EINVAL;
 			goto out;
 		}
@@ -143,7 +143,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 			sampv, &in_len, aes->intermediate_buffer,
 			&intermediate_len);
 		if (n!=RESAMPLER_ERR_SUCCESS || in_len != sampc/2) {
-			warning("mpa: downsample error: %s %d %d\n",
+			error("MPA enc downsample error: %s %d %d\n",
 				strerror(n), in_len, sampc/2);
 			return EPROTO;
 		}
@@ -151,7 +151,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 			aes->intermediate_buffer, intermediate_len,
 			buf+4, (*len)-4);
 #ifdef DEBUG
-		info("mpa encode %d %d %d %d %d\n",intermediate_len,sampc,
+		debug("MPA enc %d %d %d %d %d\n",intermediate_len,sampc,
 			aes->channels,*len,n);
 #endif
 	}
@@ -160,7 +160,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 			(int)(sampc/2), buf+4, (*len)-4);
 
 	if (n < 0) {
-		error("mpa: encode error: %s\n", strerror((int)n));
+		error("MPA enc error %s\n", strerror((int)n));
 		return EPROTO;
 	}
 
@@ -172,7 +172,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 		*len = 0;
 
 #ifdef DEBUG
-	info("mpa encode %d %d %d %d\n",sampc,aes->channels,*len,n);
+	debug("MPA enc done %d %d %d %d\n",sampc,aes->channels,*len,n);
 #endif
 	return 0;
 }

--- a/modules/mpa/encode.c
+++ b/modules/mpa/encode.c
@@ -23,6 +23,9 @@ static void destructor(void *arg)
 {
 	struct auenc_state *aes = arg;
 
+	if(aes->resampler)
+		speex_resampler_destroy(aes->resampler);
+
 	if (aes->enc)
 		twolame_close(&aes->enc);
 #ifdef DEBUG
@@ -51,7 +54,7 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	aes = mem_zalloc(sizeof(*aes), destructor);
 	aes->enc = twolame_init();
 	if (!aes->enc) {
-		error("mpa: encoder create failed");
+		error("mpa: encoder create failed\n");
 		mem_deref(aes);
 		return ENOMEM;
 	}
@@ -96,9 +99,9 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 		err=EINVAL;
 		goto out;
 	}
-
+#ifdef DEBUG
 	twolame_print_config(aes->enc);
-
+#endif
 	if (prm.samplerate != 48000) {
 		aes->resampler = speex_resampler_init(2, 48000,
 			prm.samplerate, 3, &result);

--- a/modules/mpa/encode.c
+++ b/modules/mpa/encode.c
@@ -23,13 +23,15 @@ static void destructor(void *arg)
 {
 	struct auenc_state *aes = arg;
 
-	if(aes->resampler)
+	if(aes->resampler) {
 		speex_resampler_destroy(aes->resampler);
+		aes->resampler = NULL;
+	}
 
 	if (aes->enc)
 		twolame_close(&aes->enc);
 #ifdef DEBUG
-	debug("mpa: encoder destroyed\n");
+	info("mpa encode destroyed\n");
 #endif
 }
 
@@ -47,7 +49,6 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 
 	aes = *aesp;
 	if (aes) {
-		info("ever?");
 		mem_deref(aes);
 	}
 
@@ -60,7 +61,7 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	}
 	aes->channels = ac->ch;
 #ifdef DEBUG
-	debug("mpa: encoder created %s\n",fmtp);
+	info("mpa: encoder created %s\n",fmtp);
 #endif
 
 	prm.samplerate = 32000;
@@ -150,7 +151,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 			aes->intermediate_buffer, intermediate_len,
 			buf+4, (*len)-4);
 #ifdef DEBUG
-		debug("mpa encode %d %d %d %d %d\n",intermediate_len,sampc,
+		info("mpa encode %d %d %d %d %d\n",intermediate_len,sampc,
 			aes->channels,*len,n);
 #endif
 	}
@@ -171,7 +172,7 @@ int mpa_encode_frm(struct auenc_state *aes, uint8_t *buf, size_t *len,
 		*len = 0;
 
 #ifdef DEBUG
-	debug("mpa encode %d %d %d %d\n",sampc,aes->channels,*len,n);
+	info("mpa encode %d %d %d %d\n",sampc,aes->channels,*len,n);
 #endif
 	return 0;
 }

--- a/modules/mpa/encode.c
+++ b/modules/mpa/encode.c
@@ -23,7 +23,7 @@ static void destructor(void *arg)
 {
 	struct auenc_state *aes = arg;
 
-	if(aes->resampler) {
+	if (aes->resampler) {
 		speex_resampler_destroy(aes->resampler);
 		aes->resampler = NULL;
 	}

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -82,8 +82,8 @@ static struct aucodec mpa = {
 	.pt       = "14",
 	.name      = "MPA",
 	.srate     = 90000,
-	.ch       = 2,
-	.fmtp      = "",
+	.ch       = 1,				/* MPA does not expect channels count, even thoes it is stereo */
+	.fmtp      = "layer=2",
 	.encupdh   = mpa_encode_update,
 	.ench      = mpa_encode_frm,
 	.decupdh   = mpa_decode_update,

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -79,8 +79,7 @@
 
 
 static struct aucodec mpa = {
-	.pt       = NULL,	/* for the time being, to cope
-with AVT AC1 interop problems, we do not use "14" here */
+	.pt       = "14",
 	.name      = "MPA",
 	.srate     = 90000,
 	.ch       = 1,

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -82,7 +82,7 @@ static struct aucodec mpa = {
 	.pt       = "14",
 	.name      = "MPA",
 	.srate     = 90000,
-	.ch       = 1,
+	.ch       = 2,
 	.fmtp      = "",
 	.encupdh   = mpa_encode_update,
 	.ench      = mpa_encode_frm,
@@ -106,7 +106,7 @@ static int module_init(void)
 	if (0 == conf_get_u32(conf, "mpa_bitrate", &value)) {
 		if (value<8000 || value>384000) {
 			error("MPA bitrate between 8000 and "
-				"384000 are allowed.");
+				"384000 are allowed.\n");
 			return -1;
 		}
 
@@ -134,7 +134,7 @@ static int module_init(void)
 			break;
 		default:
 			error("MPA samplerates of 16, 22.05, 24, 32, "
-				"44.1, and 48 kHz are allowed.");
+				"44.1, and 48 kHz are allowed.\n");
 			return -1;
 		}
 		(void)re_snprintf(fmtp+strlen(fmtp),
@@ -153,7 +153,7 @@ static int module_init(void)
 			&& strcmp(mode,"single_channel")
 			&& strcmp(mode,"dual_channel")) {
 			error("MPA mode: Permissible values are stereo, "
-			    "joint_stereo, single_channel, dual_channel");
+			    "joint_stereo, single_channel, dual_channel.\n");
 			return -1;
 		}
 
@@ -170,7 +170,7 @@ static int module_init(void)
 	/* init decoder library */
 	res = mpg123_init();
 	if (res != MPG123_OK) {
-		error("MPA libmpg123 init error %s",
+		error("MPA libmpg123 init error %s\n",
 			mpg123_plain_strerror(res));
 		return -1;
 	}

--- a/modules/mpa/sdp.c
+++ b/modules/mpa/sdp.c
@@ -42,13 +42,13 @@ void mpa_decode_fmtp(struct mpa_param *prm, const char *fmtp)
 
 	if (fmt_param_get(&pl, "mode", &val)) {
 
-		if (!strncmp("stereo",pl.p,pl.l))
+		if (!strncmp("stereo",val.p,val.l))
 			prm->mode = STEREO;
-		else if (!strncmp("joint_stereo",pl.p,pl.l))
+		else if (!strncmp("joint_stereo",val.p,val.l))
 			prm->mode = JOINT_STEREO;
-		else if (!strncmp("single_channel",pl.p,pl.l))
+		else if (!strncmp("single_channel",val.p,val.l))
 			prm->mode = SINGLE_CHANNEL;
-		else if (!strncmp("dual_channel",pl.p,pl.l))
+		else if (!strncmp("dual_channel",val.p,val.l))
 			prm->mode = DUAL_CHANNEL;
 	}
 }

--- a/src/audio.c
+++ b/src/audio.c
@@ -278,7 +278,7 @@ static bool aucodec_equal(const struct aucodec *a, const struct aucodec *b)
 	if (!a || !b)
 		return false;
 
-	return get_srate(a) == get_srate(b) && a->ch == b->ch;
+	return get_srate(a) == get_srate(b) && get_ch(a) == get_ch(b);
 }
 
 
@@ -337,8 +337,8 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	tx->mb->end = STREAM_PRESZ + len;
 
 	if (mbuf_get_left(tx->mb)) {
-
-		err = stream_send(a->strm, tx->marker, -1, tx->ts, tx->mb);
+		if(len)
+			err = stream_send(a->strm, tx->marker, -1, tx->ts, tx->mb);
 		if (err)
 			goto out;
 	}


### PR DESCRIPTION
I improve the MPA codec module.

Fixes where:
1) Error in SDP handling
2) Memory leaks
3) Sending of empty RTP packets

In addition, I did some cleanups.

One issue remains, the RTP timestamp are not set correctly (they are incremented by 20ms), which is not correct. But I do not have an idea on how to change the code to query the MPA module about the actual and current frame duration

