### PR TITLE
Use _POSIX_PATH_MAX for all buffers that hold filesystem paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ CXXFLAGS  += -I$(LIBREM_PATH)/include
 CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
 CXXFLAGS  += $(EXTRA_CXXFLAGS)
 
+# XXX: GNU libc
+CPPFLAGS += -D_XOPEN_SOURCE=500
+
 # XXX: common for C/C++
 CPPFLAGS += -DHAVE_INTTYPES_H
 

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ $(TEST_BIN):	$(STATICLIB) $(TEST_OBJS)
 
 $(BUILD)/%.o: %.c $(BUILD) Makefile $(APP_MK)
 	@echo "  CC      $@"
-	$(HIDE)$(CC) $(CFLAGS) -c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@ $(DFLAGS)
 
 $(BUILD)/%.o: %.cpp $(BUILD) Makefile $(APP_MK)
 	@echo "  CXX     $@"
@@ -227,11 +227,11 @@ $(BUILD)/%.o: %.cpp $(BUILD) Makefile $(APP_MK)
 
 $(BUILD)/%.o: %.m $(BUILD) Makefile $(APP_MK)
 	@echo "  OC      $@"
-	$(HIDE)$(CC) $(CFLAGS) $(OBJCFLAGS) -c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) $(OBJCFLAGS) -c $< -o $@ $(DFLAGS)
 
 $(BUILD)/%.o: %.S $(BUILD) Makefile $(APP_MK)
 	@echo "  AS      $@"
-	$(HIDE)$(CC) $(CFLAGS) -c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@ $(DFLAGS)
 
 $(BUILD): Makefile
 	@mkdir -p $(BUILD)/src $(MOD_BLD) $(BUILD)/test/mock $(BUILD)/test/sip

--- a/mk/mod.mk
+++ b/mk/mod.mk
@@ -33,36 +33,36 @@ ifeq ($(STATIC),)
 
 $(MOD)$(MOD_SUFFIX): $($(MOD)_OBJS)
 	@echo "  LD [M]  $@"
-	$(HIDE)$(LD) $(LFLAGS) $(SH_LFLAGS) $(MOD_LFLAGS) \
-		$($(basename $@)_OBJS) \
-		$($(basename $@)_LFLAGS) -L$(LIBRE_SO) -lre -o $@
+	$(HIDE)$(LD) $(LFLAGS) $(SH_LFLAGS) $(MOD_LFLAGS) $($(MOD)_OBJS) \
+		$($(MOD)_LFLAGS) -L$(LIBRE_SO) -lre -o $@
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.c $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  CC [M]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) $($(call modulename,$@)_CFLAGS) \
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) $($(MOD)_CFLAGS) \
 		-c $< -o $@ $(DFLAGS)
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.m $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  OC [M]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) $($(call modulename,$@)_CFLAGS) $(OBJCFLAGS) \
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) $($(MOD)_CFLAGS) $(OBJCFLAGS) \
 		-c $< -o $@ $(DFLAGS)
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.cpp $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  CXX [M] $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CXX) $(CXXFLAGS) $($(call modulename,$@)_CXXFLAGS) \
-		-c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CXX) $(CPPFLAGS) $(CXXFLAGS) \
+		$($(MOD)_CXXFLAGS) -c $< -o $@ $(DFLAGS)
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.S $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  AS [M]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) -DMOD_NAME=\"$(MOD)\" -c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) -DMOD_NAME=\"$(MOD)\" -c $< -o $@ \
+		$(DFLAGS)
 
 else
 
@@ -78,14 +78,14 @@ $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.c $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  CC [m]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) $($(call modulename,$@)_CFLAGS) \
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) $($(MOD)_CFLAGS) \
 		-DMOD_NAME=\"$(MOD)\" -c $< -o $@ $(DFLAGS)
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.m $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  OC [m]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) $($(call modulename,$@)_CFLAGS) $(OBJCFLAGS) \
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) $($(MOD)_CFLAGS) $(OBJCFLAGS) \
 		-DMOD_NAME=\"$(MOD)\" -c $< -o $@ $(DFLAGS)
 
 
@@ -93,13 +93,14 @@ $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.cpp $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  CXX [m] $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CXX) $(CXXFLAGS) $($(call modulename,$@)_CXXFLAGS) \
+	$(HIDE)$(CXX) $(CPPFLAGS) $(CXXFLAGS) $($(MOD)_CXXFLAGS) \
 		-DMOD_NAME=\"$(MOD)\" -c $< -o $@ $(DFLAGS)
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.S $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk
 	@echo "  AS [m]  $@"
 	@mkdir -p $(dir $@)
-	$(HIDE)$(CC) $(CFLAGS) -DMOD_NAME=\"$(MOD)\" -c $< -o $@ $(DFLAGS)
+	$(HIDE)$(CC) $(CPPFLAGS) $(CFLAGS) -DMOD_NAME=\"$(MOD)\" -c $< -o $@ \
+		$(DFLAGS)
 
 endif

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 - 2015 Creytiv.com
  */
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 
@@ -121,7 +122,7 @@ static int line_handler(const struct pl *addr)
  */
 static int account_read_file(void)
 {
-	char path[256] = "", file[256] = "";
+	char path[_POSIX_PATH_MAX] = "", file[_POSIX_PATH_MAX] = "";
 	uint32_t n;
 	int err;
 

--- a/modules/contact/contact.c
+++ b/modules/contact/contact.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 - 2015 Creytiv.com
  */
+#include <limits.h>
 #include <string.h>
 #include <re.h>
 #include <baresip.h>
@@ -174,7 +175,7 @@ static int write_template(const char *file)
 
 static int module_init(void)
 {
-	char path[256] = "", file[256] = "";
+	char path[_POSIX_PATH_MAX] = "", file[_POSIX_PATH_MAX] = "";
 	int err;
 
 	err = conf_path_get(path, sizeof(path));

--- a/modules/uuid/uuid.c
+++ b/modules/uuid/uuid.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -88,7 +89,7 @@ static int uuid_load(const char *file, char *uuid, size_t sz)
 static int module_init(void)
 {
 	struct config *cfg = conf_config();
-	char path[256];
+	char path[_POSIX_PATH_MAX];
 	int err = 0;
 
 	err = conf_path_get(path, sizeof(path));

--- a/modules/zrtp/zrtp.c
+++ b/modules/zrtp/zrtp.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 #include <zrtp.h>
@@ -318,8 +319,8 @@ static const struct cmd cmdv[] = {
 static int module_init(void)
 {
 	zrtp_status_t s;
-	char config_path[256] = "";
-	char zrtp_zid_path[256] = "";
+	char config_path[_POSIX_PATH_MAX] = "";
+	char zrtp_zid_path[_POSIX_PATH_MAX] = "";
 	FILE *f;
 	int err;
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -5,6 +5,7 @@
  */
 #define _DEFAULT_SOURCE 1
 #define _BSD_SOURCE 1
+#include <limits.h>
 #include <fcntl.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
@@ -154,7 +155,7 @@ void conf_path_set(const char *path)
  */
 int conf_path_get(char *path, size_t sz)
 {
-	char buf[256];
+	char buf[_POSIX_PATH_MAX];
 	int err;
 
 	/* Use explicit conf path */
@@ -295,7 +296,7 @@ int conf_get_sa(const struct conf *conf, const char *name, struct sa *sa)
  */
 int conf_configure(void)
 {
-	char path[256], file[256];
+	char path[_POSIX_PATH_MAX], file[_POSIX_PATH_MAX];
 	int err;
 
 #if defined (WIN32)

--- a/src/module.c
+++ b/src/module.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 #include "core.h"
@@ -54,7 +55,7 @@ static const struct mod_export *find_module(const struct pl *pl)
 static int load_module(struct mod **modp, const struct pl *modpath,
 		       const struct pl *name)
 {
-	char file[256];
+	char file[_POSIX_PATH_MAX];
 	struct mod *m = NULL;
 	int err = 0;
 

--- a/src/play.c
+++ b/src/play.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <re.h>
@@ -29,7 +30,7 @@ struct play {
 #ifndef PREFIX
 #define PREFIX "/usr"
 #endif
-static char play_path[256] = PREFIX "/share/baresip";
+static char play_path[_POSIX_PATH_MAX] = PREFIX "/share/baresip";
 static struct list playl;
 
 


### PR DESCRIPTION
`_POSIX_PATH_MAX` is supposed to be supported over all filesystems on
POSIX-compliant system.  That should include network-attached filesystems and
other locations that are may not respect host OS views on path limitations.

This is a prettified version of PR #137.