### PR TITLE
sndio: use driver-suggested buffer size

### DIFF
--- a/modules/sndio/sndio.c
+++ b/modules/sndio/sndio.c
@@ -186,7 +186,7 @@ static int src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		goto out;
 	}
 
-	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
+	st->sampc = par->bufsz / 2;
 
 	st->sampv = mem_alloc(2 * st->sampc, NULL);
 	if (!st->sampv) {


### PR DESCRIPTION
Sndio provides value of buffer size (`par->bufsz`) that is equal to audio delay
in audio driver.  Using buffer under this size causes underruns without reducing delay.  As I get it, using `par->bufsz` for buffer size ensures minimal delay while saving audio driver from additional buffer management.