### PR TITLE
avformat network initialization

### DIFF
--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -346,7 +346,11 @@ static int module_init(void)
 	/* register all codecs, demux and protocols */
 	avcodec_register_all();
 	avdevice_register_all();
-	avformat_network_init();
+
+#if LIBAVFORMAT_VERSION_INT >= ((53<<16) + (13<<8) + 0)
+    avformat_network_init();
+#endif
+
 	av_register_all();
 
 	return vidsrc_register(&mod_avf, "avformat", alloc, NULL);
@@ -356,6 +360,11 @@ static int module_init(void)
 static int module_close(void)
 {
 	mod_avf = mem_deref(mod_avf);
+
+#if LIBAVFORMAT_VERSION_INT >= ((53<<16) + (13<<8) + 0)
+    avformat_network_deinit();
+#endif
+
 	return 0;
 }
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -348,7 +348,7 @@ static int module_init(void)
 	avdevice_register_all();
 
 #if LIBAVFORMAT_VERSION_INT >= ((53<<16) + (13<<8) + 0)
-    avformat_network_init();
+	avformat_network_init();
 #endif
 
 	av_register_all();
@@ -362,7 +362,7 @@ static int module_close(void)
 	mod_avf = mem_deref(mod_avf);
 
 #if LIBAVFORMAT_VERSION_INT >= ((53<<16) + (13<<8) + 0)
-    avformat_network_deinit();
+	avformat_network_deinit();
 #endif
 
 	return 0;

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -346,6 +346,7 @@ static int module_init(void)
 	/* register all codecs, demux and protocols */
 	avcodec_register_all();
 	avdevice_register_all();
+	avformat_network_init();
 	av_register_all();
 
 	return vidsrc_register(&mod_avf, "avformat", alloc, NULL);


### PR DESCRIPTION
Due to warning message:

`Using network protocols without global network initialization. Please use avformat_network_init(), this will become mandatory later.`

(I've got following warning when I use avformat library as video RTSP source - SIP call initialization)