### PR TITLE
avcodec: add initial nvenc hardware encoding support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ LIBREM_PATH	:= $(shell [ -d ../rem ] && echo "../rem")
 endif
 
 
-CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include -Wmissing-field-initializers
+CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include
 CFLAGS    += -I$(LIBREM_PATH)/include
 CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
 
-CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC) -Wmissing-field-initializers
+CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
 CXXFLAGS  += -I$(LIBREM_PATH)/include
 CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
 CXXFLAGS  += $(EXTRA_CXXFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ LIBREM_PATH	:= $(shell [ -d ../rem ] && echo "../rem")
 endif
 
 
-CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include
+CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include -Wmissing-field-initializers
 CFLAGS    += -I$(LIBREM_PATH)/include
 CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
 
-CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
+CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC) -Wmissing-field-initializers
 CXXFLAGS  += -I$(LIBREM_PATH)/include
 CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
 CXXFLAGS  += $(EXTRA_CXXFLAGS)

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -194,6 +194,7 @@ struct config_video {
 	unsigned width, height; /**< Video resolution               */
 	uint32_t bitrate;       /**< Encoder bitrate in [bit/s]     */
 	uint32_t fps;           /**< Video framerate                */
+	bool tryhwaccel;       /**< Video framerate                */
 };
 #endif
 
@@ -825,6 +826,7 @@ struct videnc_param {
 	unsigned pktsize;  /**< RTP packetsize in [bytes]  */
 	unsigned fps;      /**< Video framerate            */
 	uint32_t max_fs;
+	bool tryhwaccel;
 };
 
 struct videnc_state;

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -29,6 +29,12 @@
       $ make USE_X264=     ; use H.264 encoder from libavcodec
  \endverbatim
  *
+ * Configure options for libavcodec (nvenc):
+ *
+ \verbatim
+      video_tryhwaccel    bool
+ \endverbatim
+ *
  *
  * References:
  *

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -139,11 +139,13 @@ static int init_encoder(struct videnc_state *st)
 	debug("avcodec: tryhwaccel: %d\n", st->encprm.tryhwaccel);
 
 	if (st->encprm.tryhwaccel) {
-		if(st->codec_id == AV_CODEC_ID_H264 && (st->codec = avcodec_find_encoder_by_name("nvenc_h264"))) {
+		if (st->codec_id == AV_CODEC_ID_H264 &&
+			(st->codec = avcodec_find_encoder_by_name("nvenc_h264"))) {
 			info("avcodec: nvenc_h264 encoder activated\n");
 		}
 		else {
-			warning("avcodec: nvenc_h264_encoder not available, using software encoder\n");
+			warning("avcodec: nvenc_h264_encoder not available, \
+				using software encoder\n");
 		}
 	}
 
@@ -209,21 +211,33 @@ static int open_encoder(struct videnc_state *st,
 		st->ctx->qmax = 51;
 		st->ctx->max_qdiff = 4;
 
-		if(st->codec == avcodec_find_encoder_by_name("nvenc_h264")) {
+#ifndef USE_X264
+		if (st->codec == avcodec_find_encoder_by_name("nvenc_h264")) {
 
-			if((err = av_opt_set(st->ctx->priv_data, "preset", "llhp", 0)) < 0) {
-				debug("avcodec: nvenc_h264 setting preset \"llhp\" failed; error: %u\n", err);
-			} else {
-				debug("avcodec: nvenc_h264 preset \"llhp\" selected\n");
+			err = av_opt_set(st->ctx->priv_data,
+				"preset", "llhp", 0);
+
+			if (err < 0) {
+				debug("avcodec: nvenc_h264 setting preset \
+					\"llhp\" failed; error: %u\n", err);
 			}
+			else {
+				debug("avcodec: nvenc_h264 preset \
+					\"llhp\" selected\n");
+			}
+			err = av_opt_set_int(st->ctx->priv_data,
+				"2pass", 1, 0);
 
-			if ((err = av_opt_set_int(st->ctx->priv_data, "2pass", 1, 0)) <0) {
-				debug("avcodec: nvenc_h264 option \"2pass\" failed; error: %u\n", err);
-			} else {
-				debug("avcodec: nvenc_h264 option \"2pass\" selected\n");
+			if (err < 0) {
+				debug("avcodec: nvenc_h264 option \
+					\"2pass\" failed; error: %u\n", err);
+			}
+			else {
+				debug("avcodec: nvenc_h264 option \
+					\"2pass\" selected\n");
 			}
 		}
-
+#endif
 	}
 
 #if LIBAVCODEC_VERSION_INT >= ((53<<16)+(8<<8)+0)

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -139,8 +139,8 @@ static int init_encoder(struct videnc_state *st)
 	debug("avcodec: tryhwaccel: %d\n", st->encprm.tryhwaccel);
 
 	if (st->encprm.tryhwaccel) {
-		if (st->codec_id == AV_CODEC_ID_H264 &&
-			(st->codec = avcodec_find_encoder_by_name("nvenc_h264"))) {
+		if (st->codec_id == AV_CODEC_ID_H264 &&	(st->codec =
+			avcodec_find_encoder_by_name("nvenc_h264"))) {
 			info("avcodec: nvenc_h264 encoder activated\n");
 		}
 		else {
@@ -218,23 +218,23 @@ static int open_encoder(struct videnc_state *st,
 				"preset", "llhp", 0);
 
 			if (err < 0) {
-				debug("avcodec: nvenc_h264 setting preset \
-					\"llhp\" failed; error: %u\n", err);
+				debug("avcodec: nvenc_h264 setting preset "
+					"\"llhp\" failed; error: %u\n", err);
 			}
 			else {
-				debug("avcodec: nvenc_h264 preset \
-					\"llhp\" selected\n");
+				debug("avcodec: nvenc_h264 preset "
+					"\"llhp\" selected\n");
 			}
 			err = av_opt_set_int(st->ctx->priv_data,
 				"2pass", 1, 0);
 
 			if (err < 0) {
-				debug("avcodec: nvenc_h264 option \
-					\"2pass\" failed; error: %u\n", err);
+				debug("avcodec: nvenc_h264 option "
+					"\"2pass\" failed; error: %u\n", err);
 			}
 			else {
-				debug("avcodec: nvenc_h264 option \
-					\"2pass\" selected\n");
+				debug("avcodec: nvenc_h264 option "
+					"\"2pass\" selected\n");
 			}
 		}
 #endif

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -8,6 +8,7 @@
 #include <baresip.h>
 #include <libavcodec/avcodec.h>
 #include <libavutil/mem.h>
+#include <libavutil/opt.h>
 #ifdef USE_X264
 #include <x264.h>
 #endif
@@ -83,6 +84,7 @@ static void destructor(void *arg)
 	if (st->ctx) {
 		if (st->ctx->codec)
 			avcodec_close(st->ctx);
+		av_opt_free(st->ctx);
 		av_free(st->ctx);
 	}
 
@@ -133,7 +135,22 @@ static int decode_sdpparam_h263(struct videnc_state *st, const struct pl *name,
 
 static int init_encoder(struct videnc_state *st)
 {
-	st->codec = avcodec_find_encoder(st->codec_id);
+#ifndef USE_X264
+	debug("avcodec: tryhwaccel: %d\n", st->encprm.tryhwaccel);
+
+	if (st->encprm.tryhwaccel) {
+		if(st->codec_id == AV_CODEC_ID_H264 && (st->codec = avcodec_find_encoder_by_name("nvenc_h264"))) {
+			info("avcodec: nvenc_h264 encoder activated\n");
+		}
+		else {
+			warning("avcodec: nvenc_h264_encoder not available, using software encoder\n");
+		}
+	}
+
+	if (!st->codec)
+#endif
+		st->codec = avcodec_find_encoder(st->codec_id);
+
 	if (!st->codec)
 		return ENOENT;
 
@@ -151,6 +168,7 @@ static int open_encoder(struct videnc_state *st,
 	if (st->ctx) {
 		if (st->ctx->codec)
 			avcodec_close(st->ctx);
+		av_opt_free(st->ctx);
 		av_free(st->ctx);
 	}
 
@@ -174,6 +192,8 @@ static int open_encoder(struct videnc_state *st,
 		goto out;
 	}
 
+	av_opt_set_defaults(st->ctx);
+
 	st->ctx->bit_rate  = prm->bitrate;
 	st->ctx->width     = size->w;
 	st->ctx->height    = size->h;
@@ -188,6 +208,22 @@ static int open_encoder(struct videnc_state *st,
 		st->ctx->qmin = 10;
 		st->ctx->qmax = 51;
 		st->ctx->max_qdiff = 4;
+
+		if(st->codec == avcodec_find_encoder_by_name("nvenc_h264")) {
+
+			if((err = av_opt_set(st->ctx->priv_data, "preset", "llhp", 0)) < 0) {
+				debug("avcodec: nvenc_h264 setting preset \"llhp\" failed; error: %u\n", err);
+			} else {
+				debug("avcodec: nvenc_h264 preset \"llhp\" selected\n");
+			}
+
+			if ((err = av_opt_set_int(st->ctx->priv_data, "2pass", 1, 0)) <0) {
+				debug("avcodec: nvenc_h264 option \"2pass\" failed; error: %u\n", err);
+			} else {
+				debug("avcodec: nvenc_h264 option \"2pass\" selected\n");
+			}
+		}
+
 	}
 
 #if LIBAVCODEC_VERSION_INT >= ((53<<16)+(8<<8)+0)
@@ -213,6 +249,7 @@ static int open_encoder(struct videnc_state *st,
 		if (st->ctx) {
 			if (st->ctx->codec)
 				avcodec_close(st->ctx);
+			av_opt_free(st->ctx);
 			av_free(st->ctx);
 			st->ctx = NULL;
 		}

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -55,6 +55,7 @@ struct video_loop {
 	const struct vidcodec *vc_dec;
 	struct config_video cfg;
 	struct videnc_state *enc;
+	struct videnc_param *prm;
 	struct viddec_state *dec;
 	struct vidisp_st *vidisp;
 	struct vidsrc_st *vsrc;
@@ -240,6 +241,7 @@ static int enable_codec(struct video_loop *vl)
 	prm.fps     = vl->cfg.fps;
 	prm.pktsize = 1480;
 	prm.bitrate = vl->cfg.bitrate;
+	prm.tryhwaccel = vl->cfg.tryhwaccel;
 	prm.max_fs  = -1;
 
 	/* Use the first video codec */

--- a/src/config.c
+++ b/src/config.c
@@ -209,6 +209,7 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	}
 	(void)conf_get_u32(conf, "video_bitrate", &cfg->video.bitrate);
 	(void)conf_get_u32(conf, "video_fps", &cfg->video.fps);
+	(void)conf_get_bool(conf, "video_tryhwaccel", &cfg->video.tryhwaccel);
 #else
 	(void)size;
 #endif
@@ -285,6 +286,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "video_size\t\t\"%ux%u\"\n"
 			 "video_bitrate\t\t%u\n"
 			 "video_fps\t\t%u\n"
+			 "video_tryhwaccel\t\t%u\n"
 			 "\n"
 #endif
 			 "# AVT\n"
@@ -326,6 +328,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->video.disp_mod, cfg->video.disp_dev,
 			 cfg->video.width, cfg->video.height,
 			 cfg->video.bitrate, cfg->video.fps,
+			 cfg->video.tryhwaccel,
 #endif
 
 			 cfg->avt.rtp_tos,
@@ -461,10 +464,12 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "video_size\t\t%dx%d\n"
 			  "video_bitrate\t\t%u\n"
 			  "video_fps\t\t%u\n",
+			  "video_tryhwaccel\t\t%u\n",
 			  default_video_device(),
 			  default_video_display(),
 			  cfg->video.width, cfg->video.height,
-			  cfg->video.bitrate, cfg->video.fps);
+			  cfg->video.bitrate, cfg->video.fps,
+			  cfg->video.tryhwaccel);
 #endif
 
 	err |= re_hprintf(pf,

--- a/src/config.c
+++ b/src/config.c
@@ -59,7 +59,7 @@ static struct config core_config = {
 		"", "",
 		352, 288,
 		500000,
-		25,
+		25, false,
 	},
 #endif
 

--- a/src/video.c
+++ b/src/video.c
@@ -1080,6 +1080,7 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 		struct videnc_param prm;
 
 		prm.bitrate = v->cfg.bitrate;
+		prm.tryhwaccel = v->cfg.tryhwaccel;
 		prm.pktsize = 1024;
 		prm.fps     = get_fps(v);
 		prm.max_fs  = -1;


### PR DESCRIPTION
Nvenc allows hardware encoding support for h264/h265 on various Nvidia graphic cards from Kepler & onwards hardware.
