### PR TITLE
More diverse testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,30 @@
 language: c
 
-before_install:
-    - sudo apt-get update -qq
+os:
+    - linux
+    - osx
+
+compiler:
+    - clang
+    - gcc
+
+env:
+    - LIBRE=re-0.4.17 LIBREM=rem-0.4.7
+
+sudo: require
+
+addons:
+    apt:
+        packages:
+            libssl-dev
 
 install:
-    - wget "http://www.creytiv.com/pub/re-0.4.17.tar.gz"
-    - tar -xzf re-0.4.17.tar.gz
-    - cd re-0.4.17 && make && sudo make install && cd ..
-    - wget "http://www.creytiv.com/pub/rem-0.4.7.tar.gz"
-    - tar -xzf rem-0.4.7.tar.gz
-    - cd rem-0.4.7 && make && sudo make install && cd ..
-    - sudo ldconfig
-    - wget "https://github.com/alfredh/pytools/raw/master/ccheck.py"
+    - curl "http://www.creytiv.com/pub/${LIBRE}.tar.gz" | tar xzf -
+    - curl "http://www.creytiv.com/pub/${LIBREM}.tar.gz" | tar xzf -
+    - curl -OL 'https://github.com/alfredh/pytools/raw/master/ccheck.py'
+    - for p in ${LIBRE} ${LIBREM}; do cd $p && sudo PATH="$PATH" make install && cd - && sudo rm -Rf $p; done
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ldconfig; fi
 
 script: 
-    - make test
+    - make V=1 CCACHE= info test
     - python2 ccheck.py


### PR DESCRIPTION
Test on both Ubuntu and OS X, with both `clang` and `gcc`.  While at it, make build verbose and print build info.

Workarounds bugs that I hit and had to work around:
 * `ccache` does not play nice with `clang`; disable `ccache`;
 * build infrastructure requires compiler and all other tools in `PATH` even for `install` target alone;  pass user's `PATH` to `sudo` commands.