### PR TITLE
opensles: use left+right for stereo

### DIFF
--- a/modules/opensles/player.c
+++ b/modules/opensles/player.c
@@ -84,11 +84,14 @@ static int createPlayer(struct auplay_st *st, struct auplay_prm *prm)
 	SLDataLocator_AndroidSimpleBufferQueue loc_bufq = {
 		SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, 2
 	};
+	uint32_t ch_mask = prm->ch == 2
+		? SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT
+		: SL_SPEAKER_FRONT_CENTER;
 	SLDataFormat_PCM format_pcm = {SL_DATAFORMAT_PCM, prm->ch,
 				       prm->srate * 1000,
 				       SL_PCMSAMPLEFORMAT_FIXED_16,
 				       SL_PCMSAMPLEFORMAT_FIXED_16,
-				       SL_SPEAKER_FRONT_CENTER,
+				       ch_mask,
 				       SL_BYTEORDER_LITTLEENDIAN};
 	SLDataSource audioSrc = {&loc_bufq, &format_pcm};
 	SLDataLocator_OutputMix loc_outmix = {


### PR DESCRIPTION
if number of channels is 2, then use this
channel mask:

  SL_SPEAKER_FRONT_LEFT | SL_SPEAKER_FRONT_RIGHT

original patch from Vijay Pratap Singh

tested on an old Samsung Android phone