### PR TITLE
Use PATH_MAX for sizes of buffers that are supposed to hold paths

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1111,6 +1111,22 @@ struct commands *baresip_commands(void);
 struct player *baresip_player(void);
 
 
+/*
+ * Macros for sizes of buffers holding specific types of data
+ */
+
+/* PATH_MAX */
+#ifndef PATH_MAX
+# if defined(_POSIX_PATH_MAX)
+#  define PATH_MAX _POSIX_PATH_MAX
+# elif defined(_XOPEN_PATH_MAX)
+#  define PATH_MAX _XOPEN_PATH_MAX
+# else
+#  define PATH_MAX 512
+# endif
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 - 2015 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 
@@ -122,7 +125,7 @@ static int line_handler(const struct pl *addr, void *arg)
  */
 static int account_read_file(void)
 {
-	char path[256] = "", file[256] = "";
+	char path[PATH_MAX] = "", file[PATH_MAX] = "";
 	uint32_t n;
 	int err;
 

--- a/modules/contact/contact.c
+++ b/modules/contact/contact.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 - 2015 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <string.h>
 #include <re.h>
 #include <baresip.h>
@@ -187,7 +190,7 @@ static int write_template(const char *file)
 static int module_init(void)
 {
 	struct contacts *contacts = baresip_contacts();
-	char path[256] = "", file[256] = "";
+	char path[PATH_MAX] = "", file[PATH_MAX] = "";
 	int err;
 
 	err = conf_path_get(path, sizeof(path));

--- a/modules/uuid/uuid.c
+++ b/modules/uuid/uuid.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -88,7 +91,7 @@ static int uuid_load(const char *file, char *uuid, size_t sz)
 static int module_init(void)
 {
 	struct config *cfg = conf_config();
-	char path[256];
+	char path[PATH_MAX];
 	int err = 0;
 
 	err = conf_path_get(path, sizeof(path));

--- a/modules/zrtp/zrtp.c
+++ b/modules/zrtp/zrtp.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 #include <zrtp.h>
@@ -318,8 +321,8 @@ static const struct cmd cmdv[] = {
 static int module_init(void)
 {
 	zrtp_status_t s;
-	char config_path[256] = "";
-	char zrtp_zid_path[256] = "";
+	char config_path[PATH_MAX] = "";
+	char zrtp_zid_path[PATH_MAX] = "";
 	FILE *f;
 	int err;
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -3,12 +3,14 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
-#define _DEFAULT_SOURCE 1
-#define _BSD_SOURCE 1
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#define _BSD_SOURCE
 #include <fcntl.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <limits.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #ifdef HAVE_IO_H
@@ -155,7 +157,7 @@ void conf_path_set(const char *path)
  */
 int conf_path_get(char *path, size_t sz)
 {
-	char buf[FS_PATH_MAX];
+	char buf[PATH_MAX];
 	int err;
 
 	/* Use explicit conf path */
@@ -296,7 +298,7 @@ int conf_get_sa(const struct conf *conf, const char *name, struct sa *sa)
  */
 int conf_configure(void)
 {
-	char path[FS_PATH_MAX], file[FS_PATH_MAX];
+	char path[PATH_MAX], file[PATH_MAX];
 	int err;
 
 #if defined (WIN32)

--- a/src/core.h
+++ b/src/core.h
@@ -5,10 +5,6 @@
  */
 
 
-/* max bytes in pathname */
-#define FS_PATH_MAX 256
-
-
 /**
  * RFC 3551:
  *

--- a/src/module.c
+++ b/src/module.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <re.h>
 #include <baresip.h>
 #include "core.h"
@@ -57,7 +60,7 @@ static const struct mod_export *find_module(const struct pl *pl)
 static int load_module(struct mod **modp, const struct pl *modpath,
 		       const struct pl *name)
 {
-	char file[FS_PATH_MAX];
+	char file[PATH_MAX];
 	struct mod *m = NULL;
 	int err = 0;
 

--- a/src/play.c
+++ b/src/play.c
@@ -3,6 +3,9 @@
  *
  * Copyright (C) 2010 Creytiv.com
  */
+#define _XOPEN_SOURCE
+#define _DARWIN_C_SOURCE
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <re.h>
@@ -29,12 +32,12 @@ struct play {
 #ifndef PREFIX
 #define PREFIX "/usr"
 #endif
-static const char default_play_path[FS_PATH_MAX] = PREFIX "/share/baresip";
+static const char default_play_path[PATH_MAX] = PREFIX "/share/baresip";
 
 
 struct player {
 	struct list playl;
-	char play_path[FS_PATH_MAX];
+	char play_path[PATH_MAX];
 };
 
 
@@ -286,7 +289,7 @@ int play_file(struct play **playp, struct player *player,
 	      const char *filename, int repeat)
 {
 	struct mbuf *mb;
-	char path[FS_PATH_MAX];
+	char path[PATH_MAX];
 	uint32_t srate = 0;
 	uint8_t ch = 0;
 	int err;


### PR DESCRIPTION
This is an implementation of my approach.  After some thinking over this issue I decided that it makes sense to define a set of macros that baresip modules and downstream projects may rely.  As of this PR this set only includes `PATH_MAX`, although in future appropriate macros for URI length, error message strings length, etc. should be added.

I included `_XOPEN_SOURCE` and `_DARWIN_C_SOURCE` macros in files that end up using `PATH_MAX` in order to unhide `_POSIX_PATH_MAX` on Linux and macOS, although I still believe that `_XOPEN_SOURCE` should be defined via `CFLAGS` for all targets.  I guess it is a subject for further investigation.
