### PR TITLE
snapshot: fix after changes in command API

### DIFF
--- a/modules/snapshot/snapshot.c
+++ b/modules/snapshot/snapshot.c
@@ -77,21 +77,21 @@ static struct vidfilt snapshot = {
 
 
 static const struct cmd cmdv[] = {
-	{'O', 0, "Take video snapshot", do_snapshot },
+	{"snapshot", 'O', 0, "Take video snapshot", do_snapshot },
 };
 
 
 static int module_init(void)
 {
 	vidfilt_register(&snapshot);
-	return cmd_register(cmdv, ARRAY_SIZE(cmdv));
+	return cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
 }
 
 
 static int module_close(void)
 {
 	vidfilt_unregister(&snapshot);
-	cmd_unregister(cmdv);
+	cmd_unregister(baresip_commands(), cmdv);
 	return 0;
 }
 


### PR DESCRIPTION
Module `snapshot` was not updated after a4798e3cdb0b3758c7f11f289c28663e65da6d6c and e3ecbddba06f91c3ef5b3cd8305a8f2fdb6c9cde.  Right now it does not build.

(*Referencing PR #173 as a reminder that the issue should probably be solved before the release.*)