### PR TITLE
v4l2: pick up VID_FMT_NV12 and VID_FMT_NV21 formats as well

### DIFF
--- a/modules/v4l2/v4l2.c
+++ b/modules/v4l2/v4l2.c
@@ -77,6 +77,8 @@ static enum vidfmt match_fmt(u_int32_t fmt)
 	case V4L2_PIX_FMT_RGB32:  return VID_FMT_RGB32;
 	case V4L2_PIX_FMT_RGB565: return VID_FMT_RGB565;
 	case V4L2_PIX_FMT_RGB555: return VID_FMT_RGB555;
+	case V4L2_PIX_FMT_NV12:   return VID_FMT_NV12;
+	case V4L2_PIX_FMT_NV21:   return VID_FMT_NV21;
 	default:                  return VID_FMT_N;
 	}
 }


### PR DESCRIPTION
These are defined in `rem`'s `rem_vid.h`, and there are corresponding definitions in V4L2 API, but they somehow did not make to `v4l2` module.

(*Referencing PR #173 as a reminder that this PR might be merged before release is cut.*)