### PR TITLE
Consistently use PREFIX in absolue paths

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -433,7 +433,11 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "call_max_calls\t%u\n"
 			  "\n"
 			  "# Audio\n"
+#if defined (PREFIX)
+			  "#audio_path\t\t" PREFIX "/share/baresip\n"
+#else
 			  "#audio_path\t\t/usr/share/baresip\n"
+#endif
 			  "audio_player\t\t%s\n"
 			  "audio_source\t\t%s\n"
 			  "audio_alert\t\t%s\n"


### PR DESCRIPTION
Currently module path detection logic uses `PREFIX` if it is defined, and falls back to Linux locations if it is not.  This PR brings the same behavior to the other absolute path in configuration file - `audio_path`.

(*Referencing PR #173 because this PR should probably be merged before 0.5.0 release.*)

P.S.: Sorry for not including this with PR #175.