### PR TITLE
v4l2: don't check for native/emulated format

### DIFF
--- a/modules/v4l2/v4l2.c
+++ b/modules/v4l2/v4l2.c
@@ -221,11 +221,7 @@ static int v4l2_init_device(struct vidsrc_st *st, const char *dev_name,
 			fmts.index++) {
 		if (match_fmt(fmts.pixelformat) != VID_FMT_N) {
 			st->pixfmt = fmts.pixelformat;
-#ifdef HAVE_LIBV4L2
-			/* Prefer native formats */
-			if (fmts.flags ^ V4L2_FMT_FLAG_EMULATED)
-#endif
-				break;
+			break;
 		}
 	}
 


### PR DESCRIPTION
Libv4l2 appends emulated formats to the end of the list, so there is no real chance that native format will follow if we already stumbled upon emulated one.

Currently this change only saves one ioctl call: baresip supports only one of emulated formats, and it comes second from the end of the list.  Still libv4l2 tends to sort formats according to conversion efficiency and amount of data loss, so if at some point in future they add another emulated format that librem supports, with current algorythm baresip will fall throught the list until it picks the worse format.