### PR TITLE
prepare nvenc_h264 code for ffmpeg >= 3.2.x

### DIFF
--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -220,29 +220,30 @@ static int open_encoder(struct videnc_state *st,
 		st->ctx->max_qdiff = 4;
 
 #ifndef USE_X264
-		if (st->codec == avcodec_find_encoder_by_name("nvenc_h264")) {
+		if (st->codec == avcodec_find_encoder_by_name("nvenc_h264") ||
+			st->codec == avcodec_find_encoder_by_name("h264_nvenc")) {
 
 #if LIBAVUTIL_VERSION_INT >= ((51<<16)+(21<<8)+0)
 			err = av_opt_set(st->ctx->priv_data,
 				"preset", "llhp", 0);
 
 			if (err < 0) {
-				debug("avcodec: nvenc_h264 setting preset "
+				debug("avcodec: h264 nvenc setting preset "
 					"\"llhp\" failed; error: %u\n", err);
 			}
 			else {
-				debug("avcodec: nvenc_h264 preset "
+				debug("avcodec: h264 nvenc preset "
 					"\"llhp\" selected\n");
 			}
 			err = av_opt_set_int(st->ctx->priv_data,
 				"2pass", 1, 0);
 
 			if (err < 0) {
-				debug("avcodec: nvenc_h264 option "
+				debug("avcodec: h264 nvenc option "
 					"\"2pass\" failed; error: %u\n", err);
 			}
 			else {
-				debug("avcodec: nvenc_h264 option "
+				debug("avcodec: h264 nvenc option "
 					"\"2pass\" selected\n");
 			}
 #endif

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -221,7 +221,8 @@ static int open_encoder(struct videnc_state *st,
 
 #ifndef USE_X264
 		if (st->codec == avcodec_find_encoder_by_name("nvenc_h264") ||
-			st->codec == avcodec_find_encoder_by_name("h264_nvenc")) {
+			st->codec == avcodec_find_encoder_by_name("h264_nvenc"))
+		{
 
 #if LIBAVUTIL_VERSION_INT >= ((51<<16)+(21<<8)+0)
 			err = av_opt_set(st->ctx->priv_data,

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -221,8 +221,7 @@ static int open_encoder(struct videnc_state *st,
 
 #ifndef USE_X264
 		if (st->codec == avcodec_find_encoder_by_name("nvenc_h264") ||
-			st->codec == avcodec_find_encoder_by_name("h264_nvenc"))
-		{
+		st->codec == avcodec_find_encoder_by_name("h264_nvenc")) {
 
 #if LIBAVUTIL_VERSION_INT >= ((51<<16)+(21<<8)+0)
 			err = av_opt_set(st->ctx->priv_data,


### PR DESCRIPTION
ffmpeg 3.2 renames nvenc_h264 to h264_nvenc & drops a deprecated warning when nvenc_h264 is used.
The patch updates the nvenc_h264 section to set the encoder options on both possible selections with ffmpeg >=3.2. Additionally the debug messages are more general.