### PR TITLE
[RFC] initial support for configuring avcodec_h264dec

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -32,8 +32,8 @@
  * Config options:
  *
  \verbatim
-      avcodec_h264enc  <NAME>  ; e.g. nvenc_h264, h264_videotoolbox
-      avcodec_h264dec  <NAME>  ; e.g. nvenc_h264, h264_videotoolbox
+      avcodec_h264enc  <NAME>  ; e.g. h264_nvenc, h264_videotoolbox
+      avcodec_h264dec  <NAME>  ; e.g. h264_cuvid, h264_vda, h264_qsv
  \endverbatim
  *
  * References:

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -18,6 +18,7 @@
 
 extern const uint8_t h264_level_idc;
 extern AVCodec *avcodec_h264enc;
+extern AVCodec *avcodec_h264dec;
 
 
 /*

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -63,7 +63,8 @@ static int init_decoder(struct viddec_state *st, const char *name)
 	if (codec_id == AV_CODEC_ID_H264 && avcodec_h264dec) {
 		st->codec = avcodec_h264dec;
 		info("avcodec: h264 decoder activated\n");
-	} else {
+	}
+	else {
 		st->codec = avcodec_find_decoder(codec_id);
 		if (!st->codec)
 			return ENOENT;

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -57,9 +57,17 @@ static int init_decoder(struct viddec_state *st, const char *name)
 	if (codec_id == AV_CODEC_ID_NONE)
 		return EINVAL;
 
-	st->codec = avcodec_find_decoder(codec_id);
-	if (!st->codec)
-		return ENOENT;
+	/*
+	* Special handling of H.264 decoder
+	*/
+	if (codec_id == AV_CODEC_ID_H264 && avcodec_h264dec) {
+		st->codec = avcodec_h264dec;
+		info("avcodec: h264 decoder activated\n");
+	} else {
+		st->codec = avcodec_find_decoder(codec_id);
+		if (!st->codec)
+			return ENOENT;
+	}
 
 #if LIBAVCODEC_VERSION_INT >= ((52<<16)+(92<<8)+0)
 	st->ctx = avcodec_alloc_context3(st->codec);
@@ -210,6 +218,10 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 		case AV_PIX_FMT_YUV420P:
 		case AV_PIX_FMT_YUVJ420P:
 			frame->fmt = VID_FMT_YUV420P;
+			break;
+
+		case AV_PIX_FMT_NV12:
+			frame->fmt = VID_FMT_NV12;
 			break;
 
 		default:

--- a/rem_patch/nv12-nv21_to_rgb32.patch
+++ b/rem_patch/nv12-nv21_to_rgb32.patch
@@ -1,0 +1,100 @@
+--- rem-0.5.0.orig/src/vidconv/vconv.c	2016-12-02 19:27:50.000000000 +0100
++++ rem-0.5.0.git/src/vidconv/vconv.c	2017-01-03 17:54:44.964817119 +0100
+@@ -572,6 +572,86 @@
+ 	}
+ }
+ 
++static void nv12_to_rgb32(unsigned xoffs, unsigned width, double rw,
++                           unsigned yd, unsigned ys, unsigned ys2,
++                           uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
++                           unsigned lsd,
++                           const uint8_t *ds0, const uint8_t *ds1,
++                           const uint8_t *ds2, unsigned lss
++                           )
++{
++       unsigned x, xd, xs, xs2;
++       unsigned id, is;
++
++       (void)ds2;
++       (void)dd1;
++       (void)dd2;
++
++       for (x=0; x<width; x+=2) {
++               int ruv, guv, buv;
++               uint8_t u, v;
++
++               xd  = (x + xoffs) * 4;
++
++               xs  = (unsigned)(x * rw);
++               xs2 = (unsigned)((x+1) * rw);
++
++               id = (xd + yd*lsd);
++               is = xs/2 + ys*lss/4;
++
++               u = ds1[2*is];
++               v = ds1[2*is+1];
++               ruv = CRV[v];
++               guv = CGV[v] + CGU[u];
++               buv = CBU[u];
++
++               yuv2rgb(&dd0[id],         ds0[xs  + ys*lss],  ruv, guv, buv);
++               yuv2rgb(&dd0[id+4],       ds0[xs2 + ys*lss],  ruv, guv, buv);
++               yuv2rgb(&dd0[id   + lsd], ds0[xs  + ys2*lss], ruv, guv, buv);
++               yuv2rgb(&dd0[id+4 + lsd], ds0[xs2 + ys2*lss], ruv, guv, buv);
++       }
++}
++
++static void nv21_to_rgb32(unsigned xoffs, unsigned width, double rw,
++                           unsigned yd, unsigned ys, unsigned ys2,
++                           uint8_t *dd0, uint8_t *dd1, uint8_t *dd2,
++                           unsigned lsd,
++                           const uint8_t *ds0, const uint8_t *ds1,
++                           const uint8_t *ds2, unsigned lss
++                           )
++{
++       unsigned x, xd, xs, xs2;
++       unsigned id, is;
++
++       (void)ds2;
++       (void)dd1;
++       (void)dd2;
++
++       for (x=0; x<width; x+=2) {
++               int ruv, guv, buv;
++               uint8_t u, v;
++
++               xd  = (x + xoffs) * 4;
++
++               xs  = (unsigned)(x * rw);
++               xs2 = (unsigned)((x+1) * rw);
++
++               id = (xd + yd*lsd);
++               is = xs/2 + ys*lss/4;
++
++               v = ds1[2*is];
++               u = ds1[2*is+1];
++               ruv = CRV[v];
++               guv = CGV[v] + CGU[u];
++               buv = CBU[u];
++
++               yuv2rgb(&dd0[id],         ds0[xs  + ys*lss],  ruv, guv, buv);
++               yuv2rgb(&dd0[id+4],       ds0[xs2 + ys*lss],  ruv, guv, buv);
++               yuv2rgb(&dd0[id   + lsd], ds0[xs  + ys2*lss], ruv, guv, buv);
++               yuv2rgb(&dd0[id+4 + lsd], ds0[xs2 + ys2*lss], ruv, guv, buv);
++       }
++}
++
+ #define MAX_SRC 9
+ #define MAX_DST 8
+ 
+@@ -593,8 +673,8 @@
+ 	{rgb32_to_yuv420p,    NULL,     NULL,     NULL, NULL, NULL, NULL},
+ 	{NULL,                NULL,     NULL,     NULL, NULL, NULL, NULL},
+ 	{NULL,                NULL,     NULL,     NULL, NULL, NULL, NULL},
+-	{nv12_to_yuv420p,     NULL,     NULL,     NULL, NULL, NULL, NULL},
+-	{nv21_to_yuv420p,     NULL,     NULL,     NULL, NULL, NULL, NULL},
++	{nv12_to_yuv420p,     NULL,     NULL,     nv12_to_rgb32, NULL, NULL, NULL},
++	{nv21_to_yuv420p,     NULL,     NULL,     nv21_to_rgb32, NULL, NULL, NULL},
+ };
+ 
+ 


### PR DESCRIPTION
Dear Alfred,

since we have now the ability to do hardware accelerated encoding in the avformat module, I've also taken an attempt to implement it similar for the decoder side.

The code so far works, but still requires some discussion/extension to be fully usable, although it works with properly with "h264".

For my use-case the main open point is the pixel format returned by the decoder. I'd like to use hardware acceleration through Nvidias h264_cuvid module, which does return "NV12" pixel format, at least thats what I get so far with this implementation.
I've checked the ffmpeg sources, and the only available pixel formats for h264_cuvid are NV12 & CUDA.

My personal view is that it nv12 would be the way to go, since this is a much more widespread and used pixel format. I've also already checked the rem sources for more details. The questions arising from this are:
Is it the way to go to implement a nv12_to_rgb32() function in rem-0.5.0/src/vidconv/vconv.c?
Is there another way convert the pixel formats in case NV12 is returned, e.g. a combination of nv12_to_yuv420p & yuv420p_to_rgb32?


Best regards,
Harald

