### PR TITLE
[RFC] swscale avformat resize video output

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -48,8 +48,8 @@
 
 
 const uint8_t h264_level_idc = 0x0c;
-AVCodec *avcodec_h264enc;             /* optinal; specified H.264 encoder */
-AVCodec *avcodec_h264dec;             /* optinal; specified H.264 decoder */
+AVCodec *avcodec_h264enc;             /* optional; specified H.264 encoder */
+AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
 
 
 int avcodec_resolve_codecid(const char *s)

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -36,6 +36,7 @@ struct picsz {
 	uint8_t mpi;        /**< Minimum Picture Interval (1-32) */
 };
 
+static struct vidsz sz_dst = {0, 0};
 
 struct videnc_state {
 	AVCodec *codec;
@@ -162,6 +163,10 @@ static int init_encoder(struct videnc_state *st)
 	if (!st->codec)
 		return ENOENT;
 
+	/* TODO: Only set sz_dst when swscale is active.
+	   Is there a way to check if swscale is loaded? */
+	(void)conf_get_vidsz(conf_cur(), "video_size", &sz_dst);
+
 	return 0;
 }
 
@@ -205,8 +210,16 @@ static int open_encoder(struct videnc_state *st,
 	av_opt_set_defaults(st->ctx);
 
 	st->ctx->bit_rate  = prm->bitrate;
-	st->ctx->width     = size->w;
-	st->ctx->height    = size->h;
+
+	if (sz_dst.w <= 0) {;
+		sz_dst.w = size->w;
+	}
+	if (sz_dst.h <= 0) {
+		sz_dst.h = size->h;
+	}
+
+	st->ctx->width     = sz_dst.w;
+	st->ctx->height    = sz_dst.h;
 	st->ctx->gop_size  = DEFAULT_GOP_SIZE;
 	st->ctx->pix_fmt   = pix_fmt;
 	st->ctx->time_base.num = 1;


### PR DESCRIPTION
Dear Alfred,

below pull request is a "draft" which works, for enabling resizing the video within avformat, using swscale & video_size in the config.
The PR is at this stage to be considered as draft. There are too many unclear questions how to handle things the way to suite baresips overall design.

Points are the following:
- Currently there is only video_size in the config. The PR uses video_size for setting the "output" (SIP transfered) video_size. The same value is also used across modules for setting the video input size. How should be distinguish between sz_src (size source/input) & sz_dst (destination/output) in future? Do we want separate config values, or eventually introduce a swscale / aformat parameters? The PR uses video_size for sz_dst.
- Is there a way to check, except evaluating the config file parameters, if a module was successfully loaded?