### PR TITLE
Configure Path where soundfiles are dumped to

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -169,3 +169,6 @@ ice_turn		no
 ice_debug		no
 ice_nomination		regular	# {regular,aggressive}
 ice_mode		full	# {full,lite}
+
+# sndfile #
+snd_path 		/tmp/

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -80,10 +80,11 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 	SNDFILE *sf;
 
 	(void)re_snprintf(filename, sizeof(filename),
-			  "/dump-%H-%s.wav",
+			  "dump-%H-%s.wav",
 			  timestamp_print, tm, enc ? "enc" : "dec");
 
 	strcpy(filepath, file_path.p);
+	strcat(filepath, '/');
 	strcat(filepath, filename);
 	strcpy(filename, filepath);
 

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -17,7 +17,6 @@
  * Example Configuration:
  \verbatim
   snd_path 					/tmp/
-	snd_file_prefix		dump
  \endverbatim
  */
 
@@ -32,9 +31,7 @@ struct sndfile_dec {
 	SNDFILE *dec;
 };
 
-static struct pl file_path = {
-	PL("./")
-};
+static char file_path[256] = ".";
 
 
 static int timestamp_print(struct re_printf *pf, const struct tm *tm)
@@ -80,13 +77,9 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 	SNDFILE *sf;
 
 	(void)re_snprintf(filename, sizeof(filename),
-			  "dump-%H-%s.wav",
+			  "%s/dump-%H-%s.wav",
+				file_path,
 			  timestamp_print, tm, enc ? "enc" : "dec");
-
-  pl_strcpy(&file_path, filepath, 256);
-	strcat(filepath, "/");
-	strcat(filepath, filename);
-	strcpy(filename, filepath);
 
 	sfinfo.samplerate = prm->srate;
 	sfinfo.channels   = prm->ch;
@@ -185,9 +178,9 @@ static int module_init(void)
 {
 	aufilt_register(&sndfile);
 
-	if (conf_get(conf_cur(), "snd_path", &file_path)) {
-		pl_set_str(&file_path, "./");
-	}
+	// TODO: conf_get_str and variable instead of struct
+
+	conf_get_str(conf_cur(), "snd_path", &file_path, 256);
 
 	info("sndfile: saving files in %s\n", file_path);
 

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -73,16 +73,19 @@ static void dec_destructor(void *arg)
 static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 {
 	char filename[128];
+	char filepath[256];
 	SF_INFO sfinfo;
 	time_t tnow = time(0);
 	struct tm *tm = localtime(&tnow);
 	SNDFILE *sf;
 
-
-
 	(void)re_snprintf(filename, sizeof(filename),
-			  "dump-%H-%s.wav",
+			  "/dump-%H-%s.wav",
 			  timestamp_print, tm, enc ? "enc" : "dec");
+
+	strcpy(filepath, file_path.p);
+	strcat(filepath, filename);
+	strcpy(filename, filepath);
 
 	sfinfo.samplerate = prm->srate;
 	sfinfo.channels   = prm->ch;

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -83,7 +83,8 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 			  "dump-%H-%s.wav",
 			  timestamp_print, tm, enc ? "enc" : "dec");
 
-	strcpy(filepath, file_path.p);
+  pl_strcpy(&file_path, filepath, 256);
+	strcat(filepath, "/");
 	strcat(filepath, filename);
 	strcpy(filename, filepath);
 

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -13,6 +13,12 @@
  * @defgroup sndfile sndfile
  *
  * Audio filter that writes audio samples to WAV-file
+ *
+ * Example Configuration:
+ \verbatim
+  snd_path 					/tmp/
+	snd_file_prefix		dump
+ \endverbatim
  */
 
 
@@ -24,6 +30,10 @@ struct sndfile_enc {
 struct sndfile_dec {
 	struct aufilt_dec_st af;  /* base class */
 	SNDFILE *dec;
+};
+
+static struct pl file_path = {
+	PL("./")
 };
 
 
@@ -67,6 +77,8 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 	time_t tnow = time(0);
 	struct tm *tm = localtime(&tnow);
 	SNDFILE *sf;
+
+
 
 	(void)re_snprintf(filename, sizeof(filename),
 			  "dump-%H-%s.wav",
@@ -168,6 +180,13 @@ static struct aufilt sndfile = {
 static int module_init(void)
 {
 	aufilt_register(&sndfile);
+
+	if (conf_get(conf_cur(), "snd_path", &file_path)) {
+		pl_set_str(&file_path, "./");
+	}
+
+	info("sndfile: saving files in %s\n", file_path);
+
 	return 0;
 }
 

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -80,7 +80,7 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 	SNDFILE *sf;
 
 	(void)re_snprintf(filename, sizeof(filename),
-			  "/dump-%H-%s.wav",
+			  "dump-%H-%s.wav",
 			  timestamp_print, tm, enc ? "enc" : "dec");
 
 	strcpy(filepath, file_path.p);

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -178,8 +178,6 @@ static int module_init(void)
 {
 	aufilt_register(&sndfile);
 
-	// TODO: conf_get_str and variable instead of struct
-
 	conf_get_str(conf_cur(), "snd_path", &file_path, 256);
 
 	info("sndfile: saving files in %s\n", file_path);

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -80,11 +80,10 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 	SNDFILE *sf;
 
 	(void)re_snprintf(filename, sizeof(filename),
-			  "dump-%H-%s.wav",
+			  "/dump-%H-%s.wav",
 			  timestamp_print, tm, enc ? "enc" : "dec");
 
 	strcpy(filepath, file_path.p);
-	strcat(filepath, '/');
 	strcat(filepath, filename);
 	strcpy(filename, filepath);
 


### PR DESCRIPTION
Dear Alfred,

I had the problem to localize my snd-dumps, when running baresip in deamon mode. Due to lack of permissions, the got not created or dropped somewhere I couldn't find.

## Solution
- path where the soundfiles are dropped is now configurable (like in other modules)

The way how the destination-filename is constructed may not be an advanced one. Feel free to edit!

Best Regards,
Martin