### PR TITLE
enabled long commands on httpd module

### DIFF
--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -37,16 +37,16 @@ static int html_print_head(struct re_printf *pf, void *unused)
 }
 
 
-static int html_print_cmd(struct re_printf *pf, const struct http_msg *req)
+static int html_print_cmd(struct re_printf *pf, const struct pl *prm)
 {
 	struct pl params;
 
-	if (!pf || !req)
+	if (!pf || !prm)
 		return EINVAL;
 
-	if (pl_isset(&req->prm)) {
-		params.p = req->prm.p + 1;
-		params.l = req->prm.l - 1;
+	if (pl_isset(prm)) {
+		params.p = prm->p + 1;
+		params.l = prm->l - 1;
 	}
 	else {
 		params.p = "h";
@@ -66,16 +66,16 @@ static int html_print_cmd(struct re_printf *pf, const struct http_msg *req)
 }
 
 
-static int html_print_raw(struct re_printf *pf, const struct http_msg *req)
+static int html_print_raw(struct re_printf *pf, const struct pl *prm)
 {
 	struct pl params;
 
-	if (!pf || !req)
+	if (!pf || !prm)
 		return EINVAL;
 
-	if (pl_isset(&req->prm)) {
-		params.p = req->prm.p + 1;
-		params.l = req->prm.l - 1;
+	if (pl_isset(prm)) {
+		params.p = prm->p + 1;
+		params.l = prm->l - 1;
 	}
 	else {
 		params.p = "h";
@@ -91,28 +91,39 @@ static void http_req_handler(struct http_conn *conn,
 			     const struct http_msg *msg, void *arg)
 {
 	(void)arg;
-
+	int err;
 	char *buf;
-	re_sdprintf(&buf, "%H", uri_header_unescape, &msg->prm);
-	pl_set_str(&msg->prm, buf);
+	struct pl nprm;
 
+	err = re_sdprintf(&buf, "%H", uri_header_unescape, &msg->prm);
+	if (err)
+		goto error;
+
+	pl_set_str(&nprm, buf);
 
 	if (0 == pl_strcasecmp(&msg->path, "/")) {
 
 		http_creply(conn, 200, "OK",
 			    "text/html;charset=UTF-8",
-			    "%H", html_print_cmd, msg);
+			    "%H", html_print_cmd, &nprm);
 	}
 	else if (0 == pl_strcasecmp(&msg->path, "/raw/")) {
 
 		http_creply(conn, 200, "OK",
 			    "text/plain;charset=UTF-8",
-			    "%H", html_print_raw, msg);
+			    "%H", html_print_raw, &nprm);
 	}
 	else {
-		http_ereply(conn, 404, "Not Found");
+		goto error;
 	}
 	mem_deref(buf);
+
+	return;
+
+	error:
+		mem_deref(buf);
+		http_ereply(conn, 404, "Not Found");
+
 }
 
 

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -92,6 +92,11 @@ static void http_req_handler(struct http_conn *conn,
 {
 	(void)arg;
 
+	char *buf;
+	re_sdprintf(&buf, "%H", uri_header_unescape, &msg->prm);
+	pl_set_str(&msg->prm, buf);
+
+
 	if (0 == pl_strcasecmp(&msg->path, "/")) {
 
 		http_creply(conn, 200, "OK",
@@ -107,6 +112,7 @@ static void http_req_handler(struct http_conn *conn,
 	else {
 		http_ereply(conn, 404, "Not Found");
 	}
+	mem_deref(buf);
 }
 
 

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -90,10 +90,10 @@ static int html_print_raw(struct re_printf *pf, const struct pl *prm)
 static void http_req_handler(struct http_conn *conn,
 			     const struct http_msg *msg, void *arg)
 {
-	(void)arg;
 	int err;
 	char *buf;
 	struct pl nprm;
+	(void)arg;
 
 	err = re_sdprintf(&buf, "%H", uri_header_unescape, &msg->prm);
 	if (err)

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -305,7 +305,8 @@ int cmd_process_long(struct commands *commands, const char *str, size_t len,
 
 	memset(&arg, 0, sizeof(arg));
 
-	err = re_regex(str, len, "[^ ]+[ ]*[~]*", &pl_name, NULL, &pl_prm);
+	err = re_regex(str, len, "[^( |%20)]+[( |%20)]*[~]*",
+				&pl_name, NULL, &pl_prm);
 	if (err) {
 		return err;
 	}

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -305,8 +305,7 @@ int cmd_process_long(struct commands *commands, const char *str, size_t len,
 
 	memset(&arg, 0, sizeof(arg));
 
-	err = re_regex(str, len, "[^( |%20)]+[( |%20)]*[~]*",
-				&pl_name, NULL, &pl_prm);
+	err = re_regex(str, len, "[^ ]+[ ]*[~]*", &pl_name, NULL, &pl_prm);
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
changed the parsing of the command that an '%20' in an url is equivalent
to an whitespace.