### PR TITLE
Video device selection bug in v4l2_codecs

### DIFF
--- a/modules/v4l2_codec/v4l2_codec.c
+++ b/modules/v4l2_codec/v4l2_codec.c
@@ -518,7 +518,7 @@ static int src_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	if (!stp || !size || !frameh)
 		return EINVAL;
 
-	if (str_isset(dev))
+	if (!str_isset(dev))
 		dev = "/dev/video0";
 
 	debug("v4l2_codec: video-source alloc (device=%s)\n", dev);


### PR DESCRIPTION
Correcting a bug making impossible to select the video device in v4l2_codecs