### PR TITLE
Call event handler for call progress/ringing after media has been set up

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1476,15 +1476,15 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 		break;
 	}
 
-	if (media)
-		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
-	else
-		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
-
 	call_stream_stop(call);
 
 	if (media)
 		call_stream_start(call, false);
+
+	if (media)
+		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
+	else
+		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
 }
 
 


### PR DESCRIPTION
The handler of the progress event may want to access the audio object of the call (for example to change the audio device). This is only possible if the media stream has already been started.