### PR TITLE
Set correct clock rate for telephone events

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -732,7 +732,7 @@ int audio_alloc(struct audio **ap, const struct config *cfg,
 		goto out;
 	}
 
-	err = telev_alloc(&a->telev, ptime, TELEV_SRATE);
+	err = telev_alloc(&a->telev, ptime);
 	if (err)
 		goto out;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -732,7 +732,7 @@ int audio_alloc(struct audio **ap, const struct config *cfg,
 		goto out;
 	}
 
-	err = telev_alloc(&a->telev, TELEV_PTIME);
+	err = telev_alloc(&a->telev, ptime, TELEV_SRATE);
 	if (err)
 		goto out;
 
@@ -1227,6 +1227,8 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 
 	stream_set_srate(a->strm, ac->crate, ac->crate);
 	stream_update_encoder(a->strm, pt_tx);
+
+	telev_set_srate(a->telev, ac->crate);
 
 	if (!tx->ausrc) {
 		err |= audio_start(a);


### PR DESCRIPTION
For telephone events the same clock rate as for audio has to be used, as both share the timestamp base.

This depends on the corresponding pull request for libre.