### PR TITLE
add RTP Header extension for Client-to-Mixer Audio Level Indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ zrtp          ZRTP media encryption module
 * RFC 4867  RTP Payload Format for the AMR and AMR-WB Audio Codecs
 * RFC 4961  Symmetric RTP / RTP Control Protocol (RTCP)
 * RFC 5168  XML Schema for Media Control
+* RFC 5285  A General Mechanism for RTP Header Extensions
 * RFC 5506  Support for Reduced-Size RTCP
 * RFC 5574  RTP Payload Format for the Speex Codec
 * RFC 5576  Source-Specific Media Attributes in SDP
@@ -341,6 +342,7 @@ zrtp          ZRTP media encryption module
 * RFC 5764  DTLS Extension to Establish Keys for SRTP
 * RFC 5780  NAT Behaviour Discovery Using STUN
 * RFC 6263  App. Mechanism for Keeping Alive NAT Associated with RTP / RTCP
+* RFC 6464  A RTP Header Extension for Client-to-Mixer Audio Level Indication
 * RFC 6716  Definition of the Opus Audio Codec
 * RFC 6886  NAT Port Mapping Protocol (NAT-PMP)
 * RFC 7587  RTP Payload Format for the Opus Speech and Audio Codec

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -200,6 +200,7 @@ struct config_audio {
 	uint32_t channels_src;  /**< Opt. channels for source       */
 	bool src_first;         /**< Audio source opened first      */
 	enum audio_mode txmode; /**< Audio transmit mode            */
+	bool level;             /**< Enable audio level indication  */
 };
 
 #ifdef USE_VIDEO
@@ -950,6 +951,7 @@ void audio_set_devicename(struct audio *a, const char *src, const char *play);
 int  audio_set_source(struct audio *au, const char *mod, const char *device);
 int  audio_set_player(struct audio *au, const char *mod, const char *device);
 void audio_encoder_cycle(struct audio *audio);
+int  audio_level_get(const struct audio *au, double *level);
 int  audio_debug(struct re_printf *pf, const struct audio *a);
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1465,6 +1465,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 	struct audio *au = arg;
 	struct sdp_extmap extmap;
 	int err;
+	(void)name;
 
 	err = sdp_extmap_decode(&extmap, value);
 	if (err) {

--- a/src/audio.c
+++ b/src/audio.c
@@ -718,7 +718,8 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 			a->rx.level_set = true;
 		}
 		else {
-			warning("audio: hdrext ignored (id=%u)\n", extv[i].id);
+			info("audio: rtp header ext ignored (id=%u)\n",
+			     extv[i].id);
 		}
 	}
 
@@ -793,10 +794,10 @@ int audio_alloc(struct audio **ap, const struct config *cfg,
 
 		a->extmap_aulevel = 1;
 
-		err |= sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					   "extmap",
-					   "%u %s",
-					   a->extmap_aulevel, uri_aulevel);
+		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
+					  "extmap",
+					  "%u %s",
+					  a->extmap_aulevel, uri_aulevel);
 		if (err)
 			goto out;
 	}
@@ -1476,14 +1477,14 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 	if (0 == pl_strcasecmp(&extmap.name, uri_aulevel)) {
 
 		if (extmap.id < RTPEXT_ID_MIN || extmap.id > RTPEXT_ID_MAX) {
-			warning("audio: id out of range (%u)\n", extmap.id);
+			warning("audio: extmap id out of range (%u)\n",
+				extmap.id);
 			return false;
 		}
 
 		au->extmap_aulevel = extmap.id;
 
-		err = sdp_media_set_lattr(stream_sdpmedia(au->strm),
-					  true,
+		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
 					  "%u %s",
 					  au->extmap_aulevel,
@@ -1493,8 +1494,6 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 
 		au->level_enabled = true;
 		info("audio: client-to-mixer audio levels enabled\n");
-
-		return true;
 	}
 
 	return false;
@@ -1529,8 +1528,8 @@ void audio_sdp_attr_decode(struct audio *a)
 		}
 	}
 
+	/* Client-to-Mixer Audio Level Indication */
 	if (a->cfg.level) {
-		/* Client-to-Mixer Audio Level Indication */
 		sdp_media_rattr_apply(stream_sdpmedia(a->strm),
 				      "extmap",
 				      extmap_handler, a);

--- a/src/config.c
+++ b/src/config.c
@@ -50,6 +50,7 @@ static struct config core_config = {
 		0,
 		false,
 		AUDIO_MODE_POLL,
+		false,
 	},
 
 #ifdef USE_VIDEO
@@ -195,6 +196,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	    0 == conf_get(conf, "audio_player", &ap))
 		cfg->audio.src_first = as.p < ap.p;
 
+	(void)conf_get_bool(conf, "audio_level", &cfg->audio.level);
+
 #ifdef USE_VIDEO
 	/* Video */
 	(void)conf_get_csv(conf, "video_source",
@@ -277,6 +280,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "ausrc_srate\t\t%u\n"
 			 "auplay_channels\t\t%u\n"
 			 "ausrc_channels\t\t%u\n"
+			 "audio_level\t\t%s\n"
 			 "\n"
 #ifdef USE_VIDEO
 			 "# Video\n"
@@ -320,6 +324,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 range_print, &cfg->audio.channels,
 			 cfg->audio.srate_play, cfg->audio.srate_src,
 			 cfg->audio.channels_play, cfg->audio.channels_src,
+			 cfg->audio.level ? "yes" : "no",
 
 #ifdef USE_VIDEO
 			 cfg->video.src_mod, cfg->video.src_dev,
@@ -447,6 +452,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#auplay_srate\t\t48000\n"
 			  "#ausrc_channels\t\t0\n"
 			  "#auplay_channels\t\t0\n"
+			  "audio_level\t\tno\n"
 			  ,
 			  poll_method_name(poll_method_best()),
 			  cfg->call.local_timeout,

--- a/src/core.h
+++ b/src/core.h
@@ -328,8 +328,9 @@ struct rtp_header;
 
 enum {STREAM_PRESZ = 4+12}; /* same as RTP_HEADER_SIZE */
 
-typedef void (stream_rtp_h)(const struct rtp_header *hdr, struct mbuf *mb,
-			    void *arg);
+typedef void (stream_rtp_h)(const struct rtp_header *hdr,
+			    struct rtpext *extv, size_t extc,
+			    struct mbuf *mb, void *arg);
 typedef void (stream_rtcp_h)(struct rtcp_msg *msg, void *arg);
 
 typedef void (stream_error_h)(struct stream *strm, int err, void *arg);
@@ -377,7 +378,7 @@ int  stream_alloc(struct stream **sp, const struct config_avt *cfg,
 		  const char *cname,
 		  stream_rtp_h *rtph, stream_rtcp_h *rtcph, void *arg);
 struct sdp_media *stream_sdpmedia(const struct stream *s);
-int  stream_send(struct stream *s, bool marker, int pt, uint32_t ts,
+int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 		 struct mbuf *mb);
 void stream_update(struct stream *s);
 void stream_update_encoder(struct stream *s, int pt_enc);

--- a/src/stream.c
+++ b/src/stream.c
@@ -172,8 +172,9 @@ static void handle_rtp(struct stream *s, const struct rtp_header *hdr,
 
 		ext_len = hdr->x.len*sizeof(uint32_t);
 		if (mb->pos < ext_len) {
-			warning("stream: corrupt mbuf,"
-				" not enough space for rtpext\n");
+			warning("stream: corrupt rtp packet,"
+				" not enough space for rtpext of %zu bytes\n",
+				ext_len);
 			return;
 		}
 

--- a/src/video.c
+++ b/src/video.c
@@ -255,7 +255,7 @@ static void vidqueue_poll(struct vtx *vtx, uint64_t jfs, uint64_t prev_jfs)
 
 		sent += mbuf_get_left(qent->mb);
 
-		stream_send(vtx->video->strm, qent->marker, qent->pt,
+		stream_send(vtx->video->strm, false, qent->marker, qent->pt,
 			    qent->ts, qent->mb);
 
 		le = le->next;
@@ -654,6 +654,7 @@ static int pt_handler(struct video *v, uint8_t pt_old, uint8_t pt_new)
 
 /* Handle incoming stream data from the network */
 static void stream_recv_handler(const struct rtp_header *hdr,
+				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, void *arg)
 {
 	struct video *v = arg;

--- a/src/video.c
+++ b/src/video.c
@@ -659,6 +659,8 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 {
 	struct video *v = arg;
 	int err;
+	(void)extv;
+	(void)extc;
 
 	if (!mb)
 		goto out;

--- a/test/call.c
+++ b/test/call.c
@@ -81,9 +81,7 @@ struct fixture {
 			       SIP_TRANSP_UDP, NULL);			\
 	TEST_ERR(err);							\
 									\
-	re_snprintf(f->buri, sizeof(f->buri), "sip:b@%J", &f->laddr_sip);\
-									\
-	conf_config()->audio.level = false;
+	re_snprintf(f->buri, sizeof(f->buri), "sip:b@%J", &f->laddr_sip);
 
 
 #define fixture_init(f)				\
@@ -752,9 +750,6 @@ int test_call_aulevel(void)
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
-	ASSERT_EQ(1, fix.a.n_established);
-	ASSERT_EQ(1, fix.b.n_established);
-
 	/* verify audio silence */
 	err = audio_level_get(call_audio(ua_call(f->a.ua)), &lvl);
 	TEST_ERR(err);
@@ -764,6 +759,8 @@ int test_call_aulevel(void)
 	ASSERT_EQ(-96, lvl);
 
  out:
+	conf_config()->audio.level = false;
+
 	fixture_close(f);
 	mem_deref(auplay);
 	mem_deref(ausrc);

--- a/test/call.c
+++ b/test/call.c
@@ -81,7 +81,9 @@ struct fixture {
 			       SIP_TRANSP_UDP, NULL);			\
 	TEST_ERR(err);							\
 									\
-	re_snprintf(f->buri, sizeof(f->buri), "sip:b@%J", &f->laddr_sip);
+	re_snprintf(f->buri, sizeof(f->buri), "sip:b@%J", &f->laddr_sip);\
+									\
+	conf_config()->audio.level = false;
 
 
 #define fixture_init(f)				\
@@ -703,3 +705,66 @@ int test_call_video(void)
 	return err;
 }
 #endif
+
+
+static void mock_sample_handler(const int16_t *sampv, size_t sampc, void *arg)
+{
+	struct fixture *fix = arg;
+	bool got_aulevel;
+
+	got_aulevel =
+		0 == audio_level_get(call_audio(ua_call(fix->a.ua)), NULL) &&
+		0 == audio_level_get(call_audio(ua_call(fix->b.ua)), NULL);
+
+	if (got_aulevel)
+		re_cancel();
+}
+
+
+int test_call_aulevel(void)
+{
+	struct fixture fix, *f = &fix;
+	struct ausrc *ausrc = NULL;
+	struct auplay *auplay = NULL;
+	double lvl;
+	int err = 0;
+
+	/* Use a low packet time, so the test completes quickly */
+	fixture_init_prm(f, ";ptime=1");
+
+	conf_config()->audio.level = true;
+
+	err = mock_ausrc_register(&ausrc);
+	TEST_ERR(err);
+	err = mock_auplay_register(&auplay, mock_sample_handler, f);
+	TEST_ERR(err);
+
+	f->estab_action = ACTION_NOTHING;
+
+	/* Make a call from A to B */
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, NULL, VIDMODE_OFF);
+	TEST_ERR(err);
+
+	/* run main-loop with timeout, wait for events */
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	ASSERT_EQ(1, fix.a.n_established);
+	ASSERT_EQ(1, fix.b.n_established);
+
+	/* verify audio silence */
+	err = audio_level_get(call_audio(ua_call(f->a.ua)), &lvl);
+	TEST_ERR(err);
+	ASSERT_EQ(-96, lvl);
+	err = audio_level_get(call_audio(ua_call(f->b.ua)), &lvl);
+	TEST_ERR(err);
+	ASSERT_EQ(-96, lvl);
+
+ out:
+	fixture_close(f);
+	mem_deref(auplay);
+	mem_deref(ausrc);
+
+	return err;
+}

--- a/test/call.c
+++ b/test/call.c
@@ -711,6 +711,8 @@ static void mock_sample_handler(const int16_t *sampv, size_t sampc, void *arg)
 {
 	struct fixture *fix = arg;
 	bool got_aulevel;
+	(void)sampv;
+	(void)sampc;
 
 	got_aulevel =
 		0 == audio_level_get(call_audio(ua_call(fix->a.ua)), NULL) &&

--- a/test/main.c
+++ b/test/main.c
@@ -33,6 +33,7 @@ static const struct test tests[] = {
 	TEST(test_call_multiple),
 	TEST(test_call_max),
 	TEST(test_call_dtmf),
+	TEST(test_call_aulevel),
 #ifdef USE_VIDEO
 	TEST(test_call_video),
 #endif

--- a/test/test.h
+++ b/test/test.h
@@ -204,6 +204,7 @@ int test_call_multiple(void);
 int test_call_max(void);
 int test_call_dtmf(void);
 int test_call_video(void);
+int test_call_aulevel(void);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
https://tools.ietf.org/html/rfc6464

requires libre from this commit or later:

https://github.com/creytiv/re/commit/1544a1e375c76a80084b411d21b0431f95e9cdfb