### PR TITLE
Make sdl2 Fullscreen Mode configurable

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -776,7 +776,8 @@ struct vidisp_st;
 
 /** Video Display parameters */
 struct vidisp_prm {
-	void *view;  /**< Optional view (set by application or module) */
+	void *view;       /**< Optional view (set by application or module) */
+	bool fullscreen;  /**< Enable fullscreen display                    */
 };
 
 typedef void (vidisp_resize_h)(const struct vidsz *size, void *arg);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -216,6 +216,7 @@ struct config_video {
 	unsigned width, height; /**< Video resolution               */
 	uint32_t bitrate;       /**< Encoder bitrate in [bit/s]     */
 	uint32_t fps;           /**< Video framerate                */
+	bool fullscreen;        /**< Enable fullscreen display      */
 };
 #endif
 

--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -134,7 +134,6 @@ static int alloc(struct vidisp_st **stp, const struct vidisp *vd,
 	int err = 0;
 
 	/* Not used by SDL */
-	(void)prm;
 	(void)dev;
 	(void)resizeh;
 	(void)arg;
@@ -147,6 +146,7 @@ static int alloc(struct vidisp_st **stp, const struct vidisp *vd,
 		return ENOMEM;
 
 	st->vd = vd;
+	st->fullscreen = prm ? prm->fullscreen : false;
 
 	tmr_start(&st->tmr, 100, event_handler, st);
 

--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -102,9 +102,11 @@ static void event_handler(void *arg)
 				     st->fullscreen ? "en" : "dis");
 
 				if (st->fullscreen)
-					st->flags |= SDL_WINDOW_FULLSCREEN;
+					st->flags |=
+						SDL_WINDOW_FULLSCREEN_DESKTOP;
 				else
-					st->flags &= ~SDL_WINDOW_FULLSCREEN;
+					st->flags &=
+						~SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 				SDL_SetWindowFullscreen(st->window, st->flags);
 				break;
@@ -195,7 +197,7 @@ static int display(struct vidisp_st *st, const char *title,
 		st->flags = SDL_WINDOW_SHOWN | SDL_WINDOW_INPUT_FOCUS;
 
 		if (st->fullscreen)
-			st->flags |= SDL_WINDOW_FULLSCREEN;
+			st->flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 
 		if (title) {
 			re_snprintf(capt, sizeof(capt), "%s - %u x %u",

--- a/src/config.c
+++ b/src/config.c
@@ -213,6 +213,7 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	}
 	(void)conf_get_u32(conf, "video_bitrate", &cfg->video.bitrate);
 	(void)conf_get_u32(conf, "video_fps", &cfg->video.fps);
+	(void)conf_get_bool(conf, "video_fullscreen", &cfg->video.fullscreen);
 #else
 	(void)size;
 #endif
@@ -471,7 +472,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#video_display\t\t%s\n"
 			  "video_size\t\t%dx%d\n"
 			  "video_bitrate\t\t%u\n"
-			  "video_fps\t\t%u\n",
+			  "video_fps\t\t%u\n"
+			  "video_fullscreen\t\tyes\n",
 			  default_video_device(),
 			  default_video_display(),
 			  cfg->video.width, cfg->video.height,

--- a/src/config.c
+++ b/src/config.c
@@ -61,6 +61,7 @@ static struct config core_config = {
 		352, 288,
 		500000,
 		25,
+		true,
 	},
 #endif
 

--- a/src/video.c
+++ b/src/video.c
@@ -871,6 +871,7 @@ static int set_vidisp(struct vrx *vrx)
 
 	vrx->vidisp = mem_deref(vrx->vidisp);
 	vrx->vidisp_prm.view = NULL;
+	vrx->vidisp_prm.fullscreen = vrx->video->cfg.fullscreen;
 
 	vd = (struct vidisp *)vidisp_find(baresip_vidispl(),
 					  vrx->video->cfg.disp_mod);


### PR DESCRIPTION
Hello Alfred,

In my application, the video output must always be fullscreen, so i added a global configuration option to specify that as default. This is currently only obeyed by the sdl2 module, but could be implemented by others?

Another Commit changes the SDL flag to SDL_WINDOW_FULLSCREEN_DESKTOP, which means that SDL won't switch resolution, but create instead will create a borderless window with the size of the desktop.
I don't know if this is preferable to everyone, maybe it should be configurable in some way, too?

Thanks for your review,
Jonathan