### PR TITLE
Hack to automatically enable PulseAudio's Echo Cancellation

### DIFF
--- a/modules/pulse/player.c
+++ b/modules/pulse/player.c
@@ -3,6 +3,10 @@
  *
  * Copyright (C) 2010 - 2016 Creytiv.com
  */
+
+/* Note: Macro needed for setenv() declaration to appear */
+#define _DEFAULT_SOURCE
+#include <stdlib.h>
 #include <pulse/pulseaudio.h>
 #include <pulse/simple.h>
 #include <pthread.h>
@@ -10,7 +14,6 @@
 #include <rem.h>
 #include <baresip.h>
 #include "pulse.h"
-
 
 struct auplay_st {
 	const struct auplay *ap;      /* inheritance */
@@ -104,6 +107,12 @@ int pulse_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	attr.prebuf    = (uint32_t)-1;
 	attr.minreq    = (uint32_t)-1;
 	attr.fragsize  = (uint32_t)-1;
+
+	/* HACK: Enable PulseAudio's Echo Cancellation through env
+	 * Explanation: To set this properly through PA's API would
+	 * mean changing all the modules code from the simple to the
+	 * full (called "asynchronous") API */
+	setenv("PULSE_PROP", "filter.want=echo-cancel", 0);
 
 	st->s = pa_simple_new(NULL,
 			      "Baresip",


### PR DESCRIPTION
Hello Alfred,

This Pull Request is more a request for comments than a real solution.

I wanted to pull the attention to PulseAudios AEC capabilities: [Reddit Thread](https://www.reddit.com/r/linux/comments/2yqfqp/just_found_that_pulseaudio_have_noise/)

There are other ways to do that via the PulseAudio API, but that does not seem to be possible without moving away from the "Simple API", which basically means rewriting the entire module.

Something else that bugs me about this approach, is that the same environment variable would also work for the ALSA module, if it is routed through PulseAudio. 

Should this option generally be configurable?
My goal is simply to avoid external configuration of baresip behaviour through environment variables.

Thanks for your time,
Jonathan