### PR TITLE
modules/zrtp: add signaling hash support

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -170,5 +170,8 @@ ice_debug		no
 ice_nomination		regular	# {regular,aggressive}
 ice_mode		full	# {full,lite}
 
+# ZRTP
+#zrtp_hash		no  # Disable SDP zrtp-hash (not recommended)
+
 # sndfile #
 snd_path 		/tmp/

--- a/src/config.c
+++ b/src/config.c
@@ -807,6 +807,11 @@ int config_write_template(const char *file, const struct config *cfg)
 			"ice_mode\t\tfull\t# {full,lite}\n");
 
 	(void)re_fprintf(f,
+			"\n# ZRTP\n"
+			"#zrtp_hash\t\tno  # Disable SDP zrtp-hash "
+			"(not recommended)\n");
+
+	(void)re_fprintf(f,
 			"\n# Menu\n"
 			"#redial_attempts\t\t3 # Num or <inf>\n"
 			"#redial_delay\t\t5 # Delay in seconds\n");


### PR DESCRIPTION
Use SDP attribute a=zrtp-hash to protect the Hello message (RFC 6189, section 8.1).
https://tools.ietf.org/html/rfc6189#section-8

This adds an extra level of protection especially when using a secure signaling channel. When an attack is detected, all incoming and outgoing UDP packets are being dropped, and the call is aborted.

If, for whatever reason, this feature is undesirable (for example, if one wants to hide the UA's ZRTP capability), it can be disabled by the configuration file option.