### PR TITLE
add support for specifying audio sample format

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -204,6 +204,8 @@ struct config_audio {
 	bool src_first;         /**< Audio source opened first      */
 	enum audio_mode txmode; /**< Audio transmit mode            */
 	bool level;             /**< Enable audio level indication  */
+	int src_fmt;            /**< Audio source sample format     */
+	int play_fmt;           /**< Audio playback sample format   */
 };
 
 #ifdef USE_VIDEO
@@ -365,9 +367,10 @@ struct ausrc_prm {
 	uint32_t   srate;       /**< Sampling rate in [Hz] */
 	uint8_t    ch;          /**< Number of channels    */
 	uint32_t   ptime;       /**< Wanted packet-time in [ms] */
+	int        fmt;         /**< Sample format (enum aufmt) */
 };
 
-typedef void (ausrc_read_h)(const int16_t *sampv, size_t sampc, void *arg);
+typedef void (ausrc_read_h)(const void *sampv, size_t sampc, void *arg);
 typedef void (ausrc_error_h)(int err, const char *str, void *arg);
 
 typedef int  (ausrc_alloc_h)(struct ausrc_st **stp, const struct ausrc *ausrc,
@@ -397,9 +400,10 @@ struct auplay_prm {
 	uint32_t   srate;       /**< Sampling rate in [Hz] */
 	uint8_t    ch;          /**< Number of channels    */
 	uint32_t   ptime;       /**< Wanted packet-time in [ms] */
+	int        fmt;         /**< Sample format (enum aufmt) */
 };
 
-typedef void (auplay_write_h)(int16_t *sampv, size_t sampc, void *arg);
+typedef void (auplay_write_h)(void *sampv, size_t sampc, void *arg);
 
 typedef int  (auplay_alloc_h)(struct auplay_st **stp, const struct auplay *ap,
 			      struct auplay_prm *prm, const char *device,

--- a/modules/alsa/alsa.c
+++ b/modules/alsa/alsa.c
@@ -29,7 +29,6 @@
 
 
 char alsa_dev[64] = "default";
-enum aufmt alsa_sample_format = AUFMT_S16LE;
 
 static struct ausrc *ausrc;
 static struct auplay *auplay;
@@ -146,24 +145,13 @@ static int alsa_init(void)
 	struct pl val;
 	int err;
 
+	/* XXX: remove check later */
 	if (0 == conf_get(conf_cur(), "alsa_sample_format", &val)) {
 
-		if (0 == pl_strcasecmp(&val, "s16")) {
-			alsa_sample_format = AUFMT_S16LE;
-		}
-		else if (0 == pl_strcasecmp(&val, "float")) {
-			alsa_sample_format = AUFMT_FLOAT;
-		}
-		else if (0 == pl_strcasecmp(&val, "s24_3le")) {
-			alsa_sample_format = AUFMT_S24_3LE;
-		}
-		else {
-			warning("alsa: unknown sample format '%r'\n", &val);
-			return EINVAL;
-		}
+		warning("alsa: alsa_sample_format is deprecated"
+			" -- use ausrc_format or auplay_format instead\n");
 
-		info("alsa: configured sample format `%s'\n",
-		     aufmt_name(alsa_sample_format));
+		(void)val;
 	}
 
 	err  = ausrc_register(&ausrc, baresip_ausrcl(),

--- a/modules/alsa/alsa.h
+++ b/modules/alsa/alsa.h
@@ -6,7 +6,7 @@
 
 
 extern char alsa_dev[64];
-extern enum aufmt alsa_sample_format;
+
 
 int alsa_reset(snd_pcm_t *pcm, uint32_t srate, uint32_t ch,
 	       uint32_t num_frames, snd_pcm_format_t pcmfmt);

--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -22,14 +22,12 @@ struct auplay_st {
 	pthread_t thread;
 	bool run;
 	snd_pcm_t *write;
-	int16_t *sampv;
-	void *xsampv;
+	void *sampv;
 	size_t sampc;
 	auplay_write_h *wh;
 	void *arg;
 	struct auplay_prm prm;
 	char *device;
-	enum aufmt aufmt;
 };
 
 
@@ -48,7 +46,6 @@ static void auplay_destructor(void *arg)
 		snd_pcm_close(st->write);
 
 	mem_deref(st->sampv);
-	mem_deref(st->xsampv);
 	mem_deref(st->device);
 }
 
@@ -67,14 +64,7 @@ static void *write_thread(void *arg)
 
 		st->wh(st->sampv, st->sampc, st->arg);
 
-		if (st->aufmt == AUFMT_S16LE) {
-			sampv = st->sampv;
-		}
-		else {
-			sampv = st->xsampv;
-			auconv_from_s16(st->aufmt, st->xsampv,
-					st->sampv, st->sampc);
-		}
+		sampv = st->sampv;
 
 		n = snd_pcm_writei(st->write, sampv, samples);
 
@@ -127,24 +117,14 @@ int alsa_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	st->ap  = ap;
 	st->wh  = wh;
 	st->arg = arg;
-	st->aufmt = alsa_sample_format;
 
 	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
 	num_frames = st->prm.srate * st->prm.ptime / 1000;
 
-	st->sampv = mem_alloc(2 * st->sampc, NULL);
+	st->sampv = mem_alloc(aufmt_sample_size(prm->fmt) * st->sampc, NULL);
 	if (!st->sampv) {
 		err = ENOMEM;
 		goto out;
-	}
-
-	if (st->aufmt != AUFMT_S16LE) {
-		size_t sz = aufmt_sample_size(st->aufmt) * st->sampc;
-		st->xsampv = mem_alloc(sz, NULL);
-		if (!st->xsampv) {
-			err = ENOMEM;
-			goto out;
-		}
 	}
 
 	err = snd_pcm_open(&st->write, st->device, SND_PCM_STREAM_PLAYBACK, 0);
@@ -154,10 +134,10 @@ int alsa_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 		goto out;
 	}
 
-	pcmfmt = aufmt_to_alsaformat(st->aufmt);
+	pcmfmt = aufmt_to_alsaformat(prm->fmt);
 	if (pcmfmt == SND_PCM_FORMAT_UNKNOWN) {
 		warning("alsa: unknown sample format '%s'\n",
-			aufmt_name(st->aufmt));
+			aufmt_name(prm->fmt));
 		err = EINVAL;
 		goto out;
 	}

--- a/modules/aubridge/play.c
+++ b/modules/aubridge/play.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "aubridge.h"
 
@@ -27,6 +28,12 @@ int play_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	if (!stp || !ap || !prm)
 		return EINVAL;
+
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("aubridge: playback: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
 
 	st = mem_zalloc(sizeof(*st), auplay_destructor);
 	if (!st)

--- a/modules/aubridge/src.c
+++ b/modules/aubridge/src.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "aubridge.h"
 
@@ -30,6 +31,12 @@ int src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	if (!stp || !as || !prm)
 		return EINVAL;
+
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("aubridge: source: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
 
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);
 	if (!st)

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -159,6 +159,12 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 	if (!stp || !as || !prm || !rh)
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("aufile: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	info("aufile: loading input file '%s'\n", dev);
 
 	st = mem_zalloc(sizeof(*st), destructor);

--- a/modules/coreaudio/player.c
+++ b/modules/coreaudio/player.c
@@ -88,6 +88,9 @@ int coreaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	(void)device;
 
+	if (!stp || !ap || !prm || prm->fmt != AUFMT_S16LE)
+		return EINVAL;
+
 	st = mem_zalloc(sizeof(*st), auplay_destructor);
 	if (!st)
 		return ENOMEM;

--- a/modules/coreaudio/recorder.c
+++ b/modules/coreaudio/recorder.c
@@ -102,7 +102,7 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	(void)device;
 	(void)errh;
 
-	if (!stp || !as || !prm)
+	if (!stp || !as || !prm || prm->fmt != AUFMT_S16LE)
 		return EINVAL;
 
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);

--- a/modules/gst/gst.c
+++ b/modules/gst/gst.c
@@ -376,6 +376,8 @@ static int gst_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	if (!prm)
 		return EINVAL;
+	if (prm->fmt != AUFMT_S16LE)
+		return ENOTSUP;
 
 	st = mem_zalloc(sizeof(*st), gst_destructor);
 	if (!st)

--- a/modules/gst1/gst.c
+++ b/modules/gst1/gst.c
@@ -383,6 +383,12 @@ static int gst_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (!prm)
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("gst: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	st = mem_zalloc(sizeof(*st), gst_destructor);
 	if (!st)
 		return ENOMEM;

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -201,6 +201,12 @@ int jack_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (prm->ch > ARRAY_SIZE(st->portv))
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("jack: playback: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	st = mem_zalloc(sizeof(*st), auplay_destructor);
 	if (!st)
 		return ENOMEM;

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -196,6 +196,12 @@ int jack_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (prm->ch > ARRAY_SIZE(st->portv))
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("jack: source: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);
 	if (!st)
 		return ENOMEM;

--- a/modules/opensles/player.c
+++ b/modules/opensles/player.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include <SLES/OpenSLES.h>
 #include "SLES/OpenSLES_Android.h"
@@ -152,6 +153,12 @@ int opensles_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	if (!stp || !ap || !prm || !wh)
 		return EINVAL;
+
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("opensles: player: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
 
 	debug("opensles: opening player %uHz, %uchannels\n",
 			prm->srate, prm->ch);

--- a/modules/opensles/recorder.c
+++ b/modules/opensles/recorder.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include <string.h>
 #include <SLES/OpenSLES.h>
@@ -164,6 +165,12 @@ int opensles_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	if (!stp || !as || !prm || !rh)
 		return EINVAL;
+
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("opensles: record: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
 
 	debug("opensles: opening recorder %uHz, %uchannels\n",
 			prm->srate, prm->ch);

--- a/modules/oss/oss.c
+++ b/modules/oss/oss.c
@@ -226,7 +226,7 @@ static int src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	(void)ctx;
 	(void)errh;
 
-	if (!stp || !as || !prm || !rh)
+	if (!stp || !as || !prm || prm->fmt != AUFMT_S16LE || !rh)
 		return EINVAL;
 
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);
@@ -285,7 +285,7 @@ static int play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	struct auplay_st *st;
 	int err;
 
-	if (!stp || !ap || !prm || !wh)
+	if (!stp || !ap || !prm || prm->fmt != AUFMT_S16LE || !wh)
 		return EINVAL;
 
 	st = mem_zalloc(sizeof(*st), auplay_destructor);

--- a/modules/portaudio/portaudio.c
+++ b/modules/portaudio/portaudio.c
@@ -99,6 +99,17 @@ static int write_callback(const void *inputBuffer, void *outputBuffer,
 }
 
 
+static PaSampleFormat aufmt_to_pasampleformat(enum aufmt fmt)
+{
+	switch (fmt) {
+
+	case AUFMT_S16LE: return paInt16;
+	case AUFMT_FLOAT: return paFloat32;
+	default: return 0;
+	}
+}
+
+
 static int read_stream_open(struct ausrc_st *st, const struct ausrc_prm *prm,
 			    uint32_t dev)
 {
@@ -109,7 +120,7 @@ static int read_stream_open(struct ausrc_st *st, const struct ausrc_prm *prm,
 	memset(&prm_in, 0, sizeof(prm_in));
 	prm_in.device           = dev;
 	prm_in.channelCount     = prm->ch;
-	prm_in.sampleFormat     = paInt16;
+	prm_in.sampleFormat     = aufmt_to_pasampleformat(prm->fmt);
 	prm_in.suggestedLatency = 0.100;
 
 	st->stream_rd = NULL;
@@ -142,7 +153,7 @@ static int write_stream_open(struct auplay_st *st,
 	memset(&prm_out, 0, sizeof(prm_out));
 	prm_out.device           = dev;
 	prm_out.channelCount     = prm->ch;
-	prm_out.sampleFormat     = paInt16;
+	prm_out.sampleFormat     = aufmt_to_pasampleformat(prm->fmt);
 	prm_out.suggestedLatency = 0.100;
 
 	st->stream_wr = NULL;

--- a/modules/sndio/sndio.c
+++ b/modules/sndio/sndio.c
@@ -154,6 +154,12 @@ static int src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (!stp || !as || !prm)
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("sndio: source: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	name = (str_isset(device)) ? device : SIO_DEVANY;
 
 	if ((st = mem_zalloc(sizeof(*st), ausrc_destructor)) == NULL)
@@ -221,6 +227,12 @@ static int play_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	if (!stp || !ap || !prm)
 		return EINVAL;
+
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("sndio: playback: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
 
 	name = (str_isset(device)) ? device : SIO_DEVANY;
 

--- a/modules/winwave/play.c
+++ b/modules/winwave/play.c
@@ -202,6 +202,12 @@ int winwave_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (!stp || !ap || !prm)
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("winwave: playback: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	st = mem_zalloc(sizeof(*st), auplay_destructor);
 	if (!st)
 		return ENOMEM;

--- a/modules/winwave/src.c
+++ b/modules/winwave/src.c
@@ -201,6 +201,12 @@ int winwave_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (!stp || !as || !prm)
 		return EINVAL;
 
+	if (prm->fmt != AUFMT_S16LE) {
+		warning("winwave: source: unsupported sample format (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);
 	if (!st)
 		return ENOMEM;

--- a/src/play.c
+++ b/src/play.c
@@ -69,7 +69,7 @@ static void tmr_polling(void *arg)
 /**
  * NOTE: DSP cannot be destroyed inside handler
  */
-static void write_handler(int16_t *sampv, size_t sampc, void *arg)
+static void write_handler(void *sampv, size_t sampc, void *arg)
 {
 	struct play *play = arg;
 	size_t sz = sampc * 2;
@@ -242,6 +242,7 @@ int play_tone(struct play **playp, struct player *player,
 	wprm.ch         = ch;
 	wprm.srate      = srate;
 	wprm.ptime      = PTIME;
+	wprm.fmt        = AUFMT_S16LE;
 
 	err = auplay_alloc(&play->auplay, baresip_auplayl(),
 			   cfg->audio.alert_mod, &wprm,

--- a/test/main.c
+++ b/test/main.c
@@ -35,6 +35,7 @@ static const struct test tests[] = {
 	TEST(test_call_dtmf),
 	TEST(test_call_aulevel),
 	TEST(test_call_progress),
+	TEST(test_call_format_float),
 #ifdef USE_VIDEO
 	TEST(test_call_video),
 	TEST(test_video),

--- a/test/mock/mock_auplay.c
+++ b/test/mock/mock_auplay.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 - 2016 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "../test.h"
 
@@ -13,7 +14,7 @@ struct auplay_st {
 
 	struct tmr tmr;
 	struct auplay_prm prm;
-	int16_t *sampv;
+	void *sampv;
 	size_t sampc;
 	auplay_write_h *wh;
 	void *arg;
@@ -72,7 +73,7 @@ static int mock_auplay_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
 
-	st->sampv = mem_zalloc(2 * st->sampc, NULL);
+	st->sampv = mem_zalloc(aufmt_sample_size(prm->fmt) * st->sampc, NULL);
 	if (!st->sampv) {
 		err = ENOMEM;
 		goto out;

--- a/test/mock/mock_ausrc.c
+++ b/test/mock/mock_ausrc.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 - 2016 Creytiv.com
  */
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "../test.h"
 
@@ -13,7 +14,7 @@ struct ausrc_st {
 
 	struct tmr tmr;
 	struct ausrc_prm prm;
-	int16_t *sampv;
+	void *sampv;
 	size_t sampc;
 	ausrc_read_h *rh;
 	void *arg;
@@ -65,7 +66,7 @@ static int mock_ausrc_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
 
-	st->sampv = mem_zalloc(2 * st->sampc, NULL);
+	st->sampv = mem_zalloc(aufmt_sample_size(prm->fmt) * st->sampc, NULL);
 	if (!st->sampv) {
 		err = ENOMEM;
 		goto out;

--- a/test/play.c
+++ b/test/play.c
@@ -39,7 +39,7 @@ static struct mbuf *generate_tone(void)
 }
 
 
-static void sample_handler(const int16_t *sampv, size_t sampc, void *arg)
+static void sample_handler(const void *sampv, size_t sampc, void *arg)
 {
 	struct test *test = arg;
 	size_t bytec = sampc * 2;

--- a/test/test.h
+++ b/test/test.h
@@ -143,7 +143,7 @@ int mock_ausrc_register(struct ausrc **ausrcp);
 
 struct auplay;
 
-typedef void (mock_sample_h)(const int16_t *sampv, size_t sampc, void *arg);
+typedef void (mock_sample_h)(const void *sampv, size_t sampc, void *arg);
 
 int mock_auplay_register(struct auplay **auplayp,
 			 mock_sample_h *sampleh, void *arg);
@@ -206,6 +206,7 @@ int test_call_dtmf(void);
 int test_call_video(void);
 int test_call_aulevel(void);
 int test_call_progress(void);
+int test_call_format_float(void);
 
 #ifdef USE_VIDEO
 int test_video(void);


### PR DESCRIPTION
Currently the audio sample format is hardcoded to Signed 16-bit (S16)
throughout the code.

There is a wish to use high-precision sample format such as Float, S24, S32 etc instead.

This will we used in Broadcasting equipment from baresip users
such as Swedish Radio.

My suggestion is to add the wanted format (`enum aufmt`) to the
ausrc/auplay parameters, and to change the callback handler type to a `void` pointer:

```
typedef void (ausrc_read_h)(const void *sampv, size_t sampc, void *arg);

typedef void (auplay_write_h)(void *sampv, size_t sampc, void *arg);
```

The desired audio sample format can then be configured in `~/.baresip/config`:

```
  ausrc_format     s16|float
  auplay_format    s16|float
```

NOTE: This is work-in-progress and not ready for merge yet.

Updated audio driver modules:

- [x] alsa
- [x] aubridge
- [x] audiounit
- [x] aufile (S16 only)
- [x] coreaudio (S16 only, deprecated)
- [x] gst  (S16 only)
- [x] gst1  (S16 only)
- [x] jack (uses only Float internally)
- [x] opensles (S16 only)
- [x] oss (S16 only, deprecated)
- [x] portaudio
- [x] pulse
- [x] rst
- [x] sndio (S16 only)
- [x] winwave (S16 only)

Reference:
https://github.com/alfredh/baresip/wiki/Audio-sample-formats
