### PR TITLE
avahi: Bugfix: Destroy resolver after callback

### DIFF
--- a/modules/avahi/avahi.c
+++ b/modules/avahi/avahi.c
@@ -250,6 +250,8 @@ static void resolve_callback(
 		warning("avahi: Resolver Error on %s: %s\n", name,
 			avahi_strerror(avahi_client_errno(avahi->client)));
 	}
+
+	avahi_service_resolver_free(r);
 }
 
 


### PR DESCRIPTION
I identified a bug in the avahi code.
Resolvers where not free'd after use, which lead to multiple contact entrys when remote nodes came off- and online in a single run.