### PR TITLE
audio: remove silence at the beginning of the RTP stream

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1380,7 +1380,7 @@ static int start_source(struct autx *tx, struct audio *a)
 		tx->psize = 2 * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 
 		if (!tx->aubuf) {
-			err = aubuf_alloc(&tx->aubuf, tx->psize * 2,
+			err = aubuf_alloc(&tx->aubuf, tx->psize,
 					  tx->psize * 30);
 			if (err)
 				return err;


### PR DESCRIPTION
Having min_sz > tx->psize in aubuf_alloc() results in insertion of 16 packets of silence at the beginning of the RTP stream. This adds an unnecessary delay.

The delay (~ 1/3 sec) is clearly noticeable when calling localhost->localhost using baresip at both ends. Use hold/resume to hear the difference.