### PR TITLE
mqtt: new module for MQTT

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -187,6 +187,9 @@ USE_SPEEX_PP := $(shell [ -f $(SYSROOT)/include/speex_preprocess.h ] || \
 USE_SYSLOG := $(shell [ -f $(SYSROOT)/include/syslog.h ] || \
 	[ -f $(SYSROOT_ALT)/include/syslog.h ] || \
 	[ -f $(SYSROOT)/local/include/syslog.h ] && echo "yes")
+HAVE_LIBMQTT := $(shell [ -f $(SYSROOT)/include/mosquitto.h ] || \
+	[ -f $(SYSROOT)/local/include/mosquitto.h ] \
+	&& echo "yes")
 USE_V4L  := $(shell [ -f $(SYSROOT)/include/libv4l1.h ] || \
 	[ -f $(SYSROOT)/local/include/libv4l1.h ] \
 	&& echo "yes")
@@ -272,6 +275,10 @@ MODULES   += menu contact vumeter mwi account natpmp httpd
 MODULES   += srtp
 MODULES   += uuid
 MODULES   += debug_cmd
+
+ifneq ($(HAVE_LIBMQTT),)
+MODULES   += mqtt
+endif
 
 ifneq ($(HAVE_PTHREAD),)
 MODULES   += aubridge aufile

--- a/modules/mqtt/README.md
+++ b/modules/mqtt/README.md
@@ -1,0 +1,59 @@
+README
+------
+
+
+This module implements an MQTT (Message Queue Telemetry Transport) client
+for publishing and subscribing to topics.
+
+
+The module is using libmosquitto
+
+
+Starting the MQTT broker:
+
+```
+$ /usr/local/sbin/mosquitto -v
+```
+
+
+Subscribing to all topics:
+
+```
+$ mosquitto_sub -t /baresip/+
+```
+
+
+Publishing to the topic:
+
+```
+$ mosquitto_pub -t /baresip/xxx -m foo=42
+```
+
+
+## Topic patterns
+
+(Outgoing direction is from baresip mqtt module to broker,
+ incoming direction is from broker to baresip mqtt module)
+
+* /baresip/event         Outgoing events from ua_event
+* /baresip/command       Incoming long command request
+* /baresip/command_resp  Outgoing long command response
+
+
+## Examples
+
+```
+/baresip/event sip:aeh@iptel.org,REGISTERING
+/baresip/event sip:aeh@iptel.org,REGISTER_OK
+/baresip/event sip:aeh@iptel.org,SHUTDOWN
+```
+
+```
+mosquitto_pub -t /baresip/command -m "/dial music"
+
+/baresip/command /dial music
+/baresip/command_resp (null)
+/baresip/event sip:aeh@iptel.org,CALL_ESTABLISHED
+/baresip/event sip:aeh@iptel.org,CALL_CLOSED
+```
+

--- a/modules/mqtt/module.mk
+++ b/modules/mqtt/module.mk
@@ -1,0 +1,14 @@
+#
+# module.mk
+#
+# Copyright (C) 2010 Creytiv.com
+#
+
+MOD		:= mqtt
+$(MOD)_SRCS	+= mqtt.c
+$(MOD)_SRCS	+= publish.c
+$(MOD)_SRCS	+= subscribe.c
+$(MOD)_LFLAGS   += -lmosquitto
+$(MOD)_CFLAGS   +=
+
+include mk/mod.mk

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -1,0 +1,157 @@
+/**
+ * @file mqtt.c Message Queue Telemetry Transport (MQTT) client
+ *
+ * Copyright (C) 2017 Creytiv.com
+ */
+
+#include <mosquitto.h>
+#include <re.h>
+#include <baresip.h>
+#include "mqtt.h"
+
+
+static char broker_host[256] = "127.0.0.1";
+static uint32_t broker_port = 1883;
+
+static struct mqtt s_mqtt;
+
+
+static void fd_handler(int flags, void *arg)
+{
+	struct mqtt *mqtt = arg;
+
+	mosquitto_loop_read(mqtt->mosq, 1);
+
+	mosquitto_loop_write(mqtt->mosq, 1);
+}
+
+
+/* XXX: use mosquitto_socket and fd_listen instead? */
+static void tmr_handler(void *data)
+{
+	struct mqtt *mqtt = data;
+	int ret;
+
+	tmr_start(&mqtt->tmr, 500, tmr_handler, mqtt);
+
+	ret = mosquitto_loop_misc(mqtt->mosq);
+	if (ret != MOSQ_ERR_SUCCESS) {
+		warning("mqtt: error in loop (%s)\n", mosquitto_strerror(ret));
+	}
+}
+
+
+/*
+ * This is called when the broker sends a CONNACK message
+ * in response to a connection.
+ */
+static void connect_callback(struct mosquitto *mosq, void *obj, int result)
+{
+	struct mqtt *mqtt = obj;
+	int err;
+	(void)mqtt;
+
+	if (result != MOSQ_ERR_SUCCESS) {
+		warning("mqtt: could not connect to broker (%s)\n",
+			mosquitto_strerror(result));
+		return;
+	}
+
+	info("mqtt: connected to broker at %s:%d\n",
+	     broker_host, broker_port);
+
+	err = mqtt_subscribe_start(mqtt);
+	if (err) {
+		warning("mqtt: subscribe_init failed (%m)\n", err);
+	}
+}
+
+
+static int module_init(void)
+{
+	const int keepalive = 60;
+	int ret;
+	int err = 0;
+
+	tmr_init(&s_mqtt.tmr);
+
+	mosquitto_lib_init();
+
+	conf_get_str(conf_cur(), "mqtt_broker_host",
+		     broker_host, sizeof(broker_host));
+	conf_get_u32(conf_cur(), "mqtt_broker_port", &broker_port);
+
+	s_mqtt.mosq = mosquitto_new("baresip", true, &s_mqtt);
+	if (!s_mqtt.mosq) {
+		warning("mqtt: failed to create client instance\n");
+		return ENOMEM;
+	}
+
+	err = mqtt_subscribe_init(&s_mqtt);
+	if (err)
+		return err;
+
+	mosquitto_connect_callback_set(s_mqtt.mosq, connect_callback);
+
+	ret = mosquitto_connect(s_mqtt.mosq, broker_host, broker_port,
+				keepalive);
+	if (ret != MOSQ_ERR_SUCCESS) {
+
+		err = ret == MOSQ_ERR_ERRNO ? errno : EIO;
+
+		warning("mqtt: failed to connect to %s:%d (%s)\n",
+			broker_host, broker_port,
+			mosquitto_strerror(ret));
+		return err;
+	}
+
+	tmr_start(&s_mqtt.tmr, 1, tmr_handler, &s_mqtt);
+
+	err = mqtt_publish_init(&s_mqtt);
+	if (err)
+		return err;
+
+	s_mqtt.fd = mosquitto_socket(s_mqtt.mosq);
+
+	err = fd_listen(s_mqtt.fd, FD_READ, fd_handler, &s_mqtt);
+	if (err)
+		return err;
+
+	info("mqtt: module loaded\n");
+
+	return err;
+}
+
+
+static int module_close(void)
+{
+	fd_close(s_mqtt.fd);
+
+	mqtt_publish_close();
+
+	mqtt_subscribe_close();
+
+	tmr_cancel(&s_mqtt.tmr);
+
+	if (s_mqtt.mosq) {
+
+		mosquitto_disconnect(s_mqtt.mosq);
+
+		mosquitto_destroy(s_mqtt.mosq);
+		s_mqtt.mosq = NULL;
+	}
+
+	mosquitto_lib_cleanup();
+
+	info("mqtt: module unloaded\n");
+
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(mqtt) = {
+	"mqtt",
+	"application",
+	module_init,
+	module_close
+};

--- a/modules/mqtt/mqtt.h
+++ b/modules/mqtt/mqtt.h
@@ -1,0 +1,26 @@
+
+
+struct mqtt {
+	struct mosquitto *mosq;
+	struct tmr tmr;
+	int fd;
+};
+
+
+/*
+ * Subscribe direction (incoming)
+ */
+
+int  mqtt_subscribe_init(struct mqtt *mqtt);
+int  mqtt_subscribe_start(struct mqtt *mqtt);
+void mqtt_subscribe_close(void);
+
+
+/*
+ * Publish direction (outgoing)
+ */
+
+int  mqtt_publish_init(struct mqtt *mqtt);
+void mqtt_publish_close(void);
+int  mqtt_publish_message(struct mqtt *mqtt, const char *topic,
+			  const char *fmt, ...);

--- a/modules/mqtt/publish.c
+++ b/modules/mqtt/publish.c
@@ -1,0 +1,115 @@
+/**
+ * @file publish.c MQTT client -- publish
+ *
+ * Copyright (C) 2017 Creytiv.com
+ */
+
+#include <mosquitto.h>
+#include <re.h>
+#include <baresip.h>
+#include "mqtt.h"
+
+
+/*
+ * This file contains functions for sending outgoing messages
+ * from baresip to broker (publish)
+ */
+
+
+/*
+ * Relay UA events as publish messages to the Broker
+ */
+static void ua_event_handler(struct ua *ua, enum ua_event ev,
+			     struct call *call, const char *prm, void *arg)
+{
+	struct mqtt *mqtt = arg;
+	const char *event_str = uag_event_str(ev);
+	struct odict *od = NULL;
+	int err;
+
+	err = odict_alloc(&od, 8);
+	if (err)
+		return;
+
+	err |= odict_entry_add(od, "type", ODICT_STRING, event_str);
+	err |= odict_entry_add(od, "accountaor", ODICT_STRING, ua_aor(ua));
+	if (err)
+		goto out;
+
+	if (call) {
+
+		const char *dir;
+
+		dir = call_is_outgoing(call) ? "outgoing" : "incoming";
+
+		err |= odict_entry_add(od, "direction", ODICT_STRING, dir );
+		err |= odict_entry_add(od, "peeruri",
+				       ODICT_STRING, call_peeruri(call));
+	}
+
+	err = mqtt_publish_message(mqtt, "/baresip/event", "%H",
+				   json_encode_odict, od);
+	if (err) {
+		warning("mqtt: failed to publish message (%m)\n", err);
+		goto out;
+	}
+
+ out:
+	mem_deref(od);
+}
+
+
+int mqtt_publish_message(struct mqtt *mqtt, const char *topic,
+			 const char *fmt, ...)
+{
+	char *message;
+	va_list ap;
+	int ret;
+	int err = 0;
+
+	if (!mqtt || !topic || !fmt)
+		return EINVAL;
+
+	va_start(ap, fmt);
+	err = re_vsdprintf(&message, fmt, ap);
+	va_end(ap);
+
+	if (err)
+		return err;
+
+	ret = mosquitto_publish(mqtt->mosq,
+				NULL,
+				topic,
+				(int)str_len(message),
+				message,
+				0,
+				false);
+	if (ret != MOSQ_ERR_SUCCESS) {
+		warning("mqtt: failed to publish (%s)\n",
+			mosquitto_strerror(ret));
+		err = EINVAL;
+		goto out;
+	}
+
+ out:
+	mem_deref(message);
+	return err;
+}
+
+
+int mqtt_publish_init(struct mqtt *mqtt)
+{
+	int err;
+
+	err = uag_event_register(ua_event_handler, mqtt);
+	if (err)
+		return err;
+
+	return err;
+}
+
+
+void mqtt_publish_close(void)
+{
+	uag_event_unregister(&ua_event_handler);
+}

--- a/modules/mqtt/subscribe.c
+++ b/modules/mqtt/subscribe.c
@@ -1,0 +1,146 @@
+/**
+ * @file subscribe.c MQTT client -- subscribe
+ *
+ * Copyright (C) 2017 Creytiv.com
+ */
+
+#include <mosquitto.h>
+#include <re.h>
+#include <baresip.h>
+#include "mqtt.h"
+
+
+static const char *subscription_pattern = "/baresip/+";
+
+
+static int print_handler(const char *p, size_t size, void *arg)
+{
+	struct mbuf *mb = arg;
+
+	return mbuf_write_mem(mb, (void *)p, size);
+}
+
+
+static void handle_command(struct mqtt *mqtt, const struct pl *msg)
+{
+	struct mbuf *resp = mbuf_alloc(1024);
+	struct re_printf pf = {print_handler, resp};
+	struct odict *od = NULL;
+	const struct odict_entry *oe_cmd, *oe_prm, *oe_tok;
+	char buf[256], resp_topic[256];
+	int err;
+
+	/* XXX: add transaction ID ? */
+
+	err = json_decode_odict(&od, 32, msg->p, msg->l, 16);
+	if (err) {
+		warning("mqtt: failed to decode JSON with %zu bytes (%m)\n",
+			msg->l, err);
+		return;
+	}
+
+	oe_cmd = odict_lookup(od, "command");
+	oe_prm = odict_lookup(od, "params");
+	oe_tok = odict_lookup(od, "token");
+	if (!oe_cmd) {
+		warning("mqtt: missing json entries\n");
+		goto out;
+	}
+
+	debug("mqtt: handle_command:  cmd='%s', token='%s'\n",
+	      oe_cmd ? oe_cmd->u.str : "",
+	      oe_tok ? oe_tok->u.str : "");
+
+	re_snprintf(buf, sizeof(buf), "%s%s%s",
+		    oe_cmd->u.str,
+		    oe_prm ? " " : "",
+		    oe_prm ? oe_prm->u.str : "");
+
+	/* Relay message to long commands */
+	err = cmd_process_long(baresip_commands(),
+			       buf,
+			       str_len(buf),
+			       &pf, NULL);
+	if (err) {
+		warning("mqtt: error processing command (%m)\n", err);
+	}
+
+	/* NOTE: the command will now write the response
+	   to the resp mbuf, send it back to broker */
+
+	re_snprintf(resp_topic, sizeof(resp_topic),
+		    "/baresip/command_resp/%s",
+		    oe_tok ? oe_tok->u.str : "nil");
+
+	err = mqtt_publish_message(mqtt, resp_topic,
+				   "%b",
+				   resp->buf, resp->end);
+	if (err) {
+		warning("mqtt: failed to publish message (%m)\n", err);
+		goto out;
+	}
+
+ out:
+	mem_deref(resp);
+	mem_deref(od);
+}
+
+
+/*
+ * This is called when a message is received from the broker.
+ */
+static void message_callback(struct mosquitto *mosq, void *obj,
+			     const struct mosquitto_message *message)
+{
+	struct mqtt *mqtt = obj;
+	struct pl msg;
+	bool match = false;
+
+	info("mqtt: got message '%b' for topic '%s'\n",
+	     (char*) message->payload, (size_t)message->payloadlen,
+	     message->topic);
+
+	msg.p = message->payload;
+	msg.l = message->payloadlen;
+
+	mosquitto_topic_matches_sub("/baresip/command", message->topic,
+				    &match);
+	if (match) {
+		info("mqtt: got message for '%s' topic\n", message->topic);
+
+		handle_command(mqtt, &msg);
+	}
+}
+
+
+int mqtt_subscribe_init(struct mqtt *mqtt)
+{
+	if (!mqtt)
+		return EINVAL;
+
+	mosquitto_message_callback_set(mqtt->mosq, message_callback);
+
+	return 0;
+}
+
+
+int mqtt_subscribe_start(struct mqtt *mqtt)
+{
+	int ret;
+
+	ret = mosquitto_subscribe(mqtt->mosq, NULL, subscription_pattern, 0);
+	if (ret != MOSQ_ERR_SUCCESS) {
+		warning("mqtt: failed to subscribe (%s)\n",
+			mosquitto_strerror(ret));
+		return EPROTO;
+	}
+
+	info("mqtt: subscribed to pattern '%s'\n", subscription_pattern);
+
+	return 0;
+}
+
+
+void mqtt_subscribe_close(void)
+{
+}

--- a/src/config.c
+++ b/src/config.c
@@ -827,6 +827,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module_app\t\t" MOD_PRE "natbd"MOD_EXT"\n");
 	(void)re_fprintf(f, "#module_app\t\t" MOD_PRE "presence"MOD_EXT"\n");
 	(void)re_fprintf(f, "#module_app\t\t" MOD_PRE "syslog"MOD_EXT"\n");
+	(void)re_fprintf(f, "#module_app\t\t" MOD_PRE "mqtt" MOD_EXT "\n");
 #ifdef USE_VIDEO
 	(void)re_fprintf(f, "module_app\t\t" MOD_PRE "vidloop"MOD_EXT"\n");
 #endif


### PR DESCRIPTION
mqtt: relay ua_event with publish

relay incoming message to long commands (with '/' prefix)

mqtt: add file for publish

mqtt: add command response

mqtt: add subscribe.c

mqtt: use fd_listen for READ/WRITE

Make + Config entry for MQTT module (#329)

* include mqtt in modules and config

* Check for mosquitto-dev

* fix mqtt module checks

* Moving MQTT config to module_app block

mqtt: add JSON payload for events

mqtt: add JSON decoding of command

mqtt: add config for broker host/port