### PR TITLE
avcodec: change x264 rate control mode to ABR

### DIFF
--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -429,7 +429,7 @@ static int open_encoder_x264(struct videnc_state *st, struct videnc_param *prm,
 	xprm.i_fps_num = prm->fps;
 	xprm.i_fps_den = 1;
 	xprm.rc.i_bitrate = prm->bitrate / 1000; /* kbit/s */
-	xprm.rc.i_rc_method = X264_RC_CQP;
+	xprm.rc.i_rc_method = X264_RC_ABR;
 	xprm.i_log_level = X264_LOG_WARNING;
 
 	/* ultrafast preset */


### PR DESCRIPTION
Just a very small fix: 
I found that the avcodec module with x264 won't obey the video_bitrate config option.
With a different rate control mode (ABR=Average-Bitrate instead of CQP=Constant-Quality), it will usually keep the bitrate around or below the configured value.