### PR TITLE
avcodec: Request Frame Refresh in more cases

### DIFF
--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -333,6 +333,7 @@ int decode_h264(struct viddec_state *st, struct vidframe *frame,
 				      " ignoring NAL\n");
 				fragment_rewind(st);
 				++st->stats.n_lost;
+				return EPROTO;
 			}
 
 			st->frag_start = st->mb->pos;
@@ -351,7 +352,7 @@ int decode_h264(struct viddec_state *st, struct vidframe *frame,
 			if (!st->frag) {
 				debug("avcodec: ignoring fragment\n");
 				++st->stats.n_lost;
-				return 0;
+				return EPROTO;
 			}
 
 			if (seq_diff(st->frag_seq, seq) != 1) {
@@ -359,7 +360,7 @@ int decode_h264(struct viddec_state *st, struct vidframe *frame,
 				fragment_rewind(st);
 				st->frag = false;
 				++st->stats.n_lost;
-				return 0;
+				return EPROTO;
 			}
 		}
 


### PR DESCRIPTION
Hello Alfred,

Previously, when packet loss occured on a H264 stream, the image would get corrupted and not recover for many seconds, until the left-to-right-rolling periodic intra-refresh came by.

Today i did some tests with simulated packet loss, and noticed that in most cases, decode_h264() won't return an error, because the missing fragment is already noticed by h264_fu_hdr_decode(), and the subsequent code returns 0;

I changed these cases to return EPROTO, and now it recovers much faster.
Only one or a few frames of a destroyed image are shown, before the video recovers, which still is annoying and probably unnecessary, but the overall experience seems to already be much better.

I'd be happy if you have some time to look into this and comment, i'm very much interested in a more robust video-stream with baresip. :)


Best Regards,
Jonathan