### PR TITLE
Vidsrc add timestamp

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -21,6 +21,12 @@ extern "C" {
 #endif
 
 
+/*
+ * Clock-rate for video timestamp
+ */
+#define VIDEO_TIMEBASE 1000000U
+
+
 /* forward declarations */
 struct sa;
 struct sdp_media;
@@ -764,7 +770,8 @@ struct vidsrc_prm {
 	double fps;       /**< Wanted framerate                            */
 };
 
-typedef void (vidsrc_frame_h)(struct vidframe *frame, void *arg);
+typedef void (vidsrc_frame_h)(struct vidframe *frame, uint64_t timestamp,
+			      void *arg);
 typedef void (vidsrc_error_h)(int err, void *arg);
 
 typedef int  (vidsrc_alloc_h)(struct vidsrc_st **vsp, const struct vidsrc *vs,
@@ -1034,6 +1041,7 @@ int   video_debug(struct re_printf *pf, const struct video *v);
 uint64_t video_calc_rtp_timestamp(int64_t pts, double fps);
 double video_calc_seconds(uint64_t rtp_ts);
 struct stream *video_strm(const struct video *v);
+double video_timestamp_to_seconds(uint64_t timestamp);
 
 
 /*

--- a/modules/avcapture/avcapture.m
+++ b/modules/avcapture/avcapture.m
@@ -234,7 +234,9 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
        fromConnection:(AVCaptureConnection *)conn
 {
 	const CVImageBufferRef b = CMSampleBufferGetImageBuffer(sampleBuffer);
+	CMTime ts = CMSampleBufferGetOutputPresentationTimeStamp(sampleBuffer);
 	struct vidframe vf;
+	uint64_t timestamp;
 
 	(void)captureOutput;
 	(void)conn;
@@ -246,8 +248,10 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 
 	vidframe_set_pixbuf(&vf, b);
 
+	timestamp = CMTimeGetSeconds(ts) * VIDEO_TIMEBASE;
+
 	if (vidframe_isvalid(&vf))
-		vsrc->frameh(&vf, vsrc->arg);
+		vsrc->frameh(&vf, timestamp, vsrc->arg);
 
 	CVPixelBufferUnlockBaseAddress(b, 0);
 }

--- a/modules/fakevideo/fakevideo.c
+++ b/modules/fakevideo/fakevideo.c
@@ -60,12 +60,16 @@ static void *read_thread(void *arg)
 
 	while (st->run) {
 
+		uint64_t timestamp;
+
 		if (tmr_jiffies() < ts) {
 			sys_msleep(4);
 			continue;
 		}
 
-		st->frameh(st->frame, st->arg);
+		timestamp = ts * VIDEO_TIMEBASE  / 1000;
+
+		st->frameh(st->frame, timestamp, st->arg);
 
 		ts += (1000/st->fps);
 	}

--- a/modules/rst/video.c
+++ b/modules/rst/video.c
@@ -62,6 +62,8 @@ static void *video_thread(void *arg)
 
 	while (st->run) {
 
+		uint64_t timestamp;
+
 		sys_msleep(4);
 
 		now = tmr_jiffies();
@@ -69,8 +71,10 @@ static void *video_thread(void *arg)
 		if (ts > now)
 			continue;
 
+		timestamp = ts * VIDEO_TIMEBASE / 1000;
+
 		pthread_mutex_lock(&st->mutex);
-		st->frameh(st->frame, st->arg);
+		st->frameh(st->frame, timestamp, st->arg);
 		pthread_mutex_unlock(&st->mutex);
 
 		ts += 1000/st->prm.fps;

--- a/modules/vidbridge/src.c
+++ b/modules/vidbridge/src.c
@@ -30,11 +30,10 @@ int vidbridge_src_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	struct vidsrc_st *st;
 	int err;
 	(void)ctx;
-	(void)prm;
 	(void)fmt;
 	(void)errorh;
 
-	if (!stp || !size || !frameh)
+	if (!stp || !prm || !size || !frameh)
 		return EINVAL;
 
 	st = mem_zalloc(sizeof(*st), destructor);
@@ -44,6 +43,7 @@ int vidbridge_src_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	st->vs     = vs;
 	st->frameh = frameh;
 	st->arg    = arg;
+	st->fps    = prm->fps;
 
 	err = str_dup(&st->device, dev);
 	if (err)
@@ -82,12 +82,15 @@ struct vidsrc_st *vidbridge_src_find(const char *device)
 }
 
 
-void vidbridge_src_input(const struct vidsrc_st *st,
+void vidbridge_src_input(struct vidsrc_st *st,
 			 const struct vidframe *frame)
 {
 	if (!st || !frame)
 		return;
 
+	/* XXX: Read from vidisp input */
+	st->timestamp += VIDEO_TIMEBASE / st->fps;
+
 	if (st->frameh)
-		st->frameh((struct vidframe *)frame, st->arg);
+		st->frameh((struct vidframe *)frame, st->timestamp, st->arg);
 }

--- a/modules/vidbridge/vidbridge.h
+++ b/modules/vidbridge/vidbridge.h
@@ -10,6 +10,8 @@ struct vidsrc_st {
 
 	struct le le;
 	struct vidisp_st *vidisp;
+	uint64_t timestamp;
+	double fps;
 	char *device;
 	vidsrc_frame_h *frameh;
 	void *arg;
@@ -43,5 +45,5 @@ int vidbridge_src_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 			const char *dev, vidsrc_frame_h *frameh,
 			vidsrc_error_h *errorh, void *arg);
 struct vidsrc_st *vidbridge_src_find(const char *device);
-void vidbridge_src_input(const struct vidsrc_st *st,
+void vidbridge_src_input(struct vidsrc_st *st,
 			 const struct vidframe *frame);

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -73,6 +73,10 @@ struct video_loop {
 		uint64_t enc_packets;
 		uint64_t disp_frames;
 	} stats;
+
+	bool timestamp_set;
+	uint64_t timestamp_base;  /* lowest timestamp */
+	uint64_t timestamp_last;  /* most recent timestamp */
 };
 
 
@@ -189,7 +193,21 @@ static int packet_handler(bool marker, uint64_t rtp_ts,
 }
 
 
-static void vidsrc_frame_handler(struct vidframe *frame, void *arg)
+static double stream_duration(const struct video_loop *vl)
+{
+	uint64_t dur;
+
+	if (vl->timestamp_set)
+		dur = vl->timestamp_last - vl->timestamp_base;
+	else
+		dur = 0;
+
+	return video_timestamp_to_seconds(dur);
+}
+
+
+static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
+				 void *arg)
 {
 	struct video_loop *vl = arg;
 	struct vidframe *f2 = NULL;
@@ -206,6 +224,20 @@ static void vidsrc_frame_handler(struct vidframe *frame, void *arg)
 	vl->src_size = frame->size;
 	vl->src_fmt = frame->fmt;
 	++vl->stats.src_frames;
+
+	/* Timestamp logic */
+	if (vl->timestamp_set) {
+		if (timestamp <= vl->timestamp_base) {
+			info("vidloop: timestamp wrapped -- reset base\n");
+			vl->timestamp_base = timestamp;
+		}
+		vl->timestamp_last = timestamp;
+	}
+	else {
+		vl->timestamp_base = timestamp;
+		vl->timestamp_last = timestamp;
+		vl->timestamp_set = true;
+	}
 
 	++vl->stat.frames;
 
@@ -259,8 +291,9 @@ static int print_stats(struct re_printf *pf, const struct video_loop *vl)
 	double real_dur = .0;
 	int err = 0;
 
-	if (vl->ts_start)
-		real_dur = 0.000001 * (double)(vl->ts_last - vl->ts_start);
+	if (vl->ts_start) {
+		real_dur = stream_duration(vl);
+	}
 
 	err |= re_hprintf(pf, "~~~~~ Videoloop summary: ~~~~~\n");
 
@@ -279,6 +312,7 @@ static int print_stats(struct re_printf *pf, const struct video_loop *vl)
 				  "  pixformat   %s\n"
 				  "  frames      %llu\n"
 				  "  framerate   %.2f fps  (avg %.2f fps)\n"
+				  "  duration    %.3f sec\n"
 				  "\n"
 				  ,
 				  vs->name,
@@ -286,7 +320,8 @@ static int print_stats(struct re_printf *pf, const struct video_loop *vl)
 				  vl->src_size.w, vl->src_size.h,
 				  vidfmt_name(vl->src_fmt),
 				  vl->stats.src_frames,
-				  vl->srcprm.fps, avg_fps);
+				  vl->srcprm.fps, avg_fps,
+				  real_dur);
 	}
 
 	/* Video conversion */
@@ -438,8 +473,9 @@ static void print_status(struct video_loop *vl)
 {
 	(void)re_fprintf(stdout,
 			 "\rstatus:"
-			 " [%s] [%s]  fmt=%s  intra=%zu "
+			 " %.3f sec [%s] [%s]  fmt=%s  intra=%zu "
 			 " EFPS=%.1f      %u kbit/s       \r",
+			 stream_duration(vl),
 			 vl->vc_enc ? vl->vc_enc->name : "",
 			 vl->vc_dec ? vl->vc_dec->name : "",
 			 vidfmt_name(vl->cfg.enc_fmt),
@@ -478,7 +514,7 @@ static void timeout_bw(void *arg)
 		return;
 	}
 
-	tmr_start(&vl->tmr_bw, 2000, timeout_bw, vl);
+	tmr_start(&vl->tmr_bw, 500, timeout_bw, vl);
 
 	calc_bitrate(vl);
 	print_status(vl);

--- a/modules/x11grab/x11grab.c
+++ b/modules/x11grab/x11grab.c
@@ -100,13 +100,14 @@ static inline uint8_t *x11grab_read(struct vidsrc_st *st)
 }
 
 
-static void call_frame_handler(struct vidsrc_st *st, uint8_t *buf)
+static void call_frame_handler(struct vidsrc_st *st, uint8_t *buf,
+			       uint64_t timestamp)
 {
 	struct vidframe frame;
 
 	vidframe_init_buf(&frame, st->pixfmt, &st->size, buf);
 
-	st->frameh(&frame, st->arg);
+	st->frameh(&frame, timestamp, st->arg);
 }
 
 
@@ -118,6 +119,8 @@ static void *read_thread(void *arg)
 
 	while (st->run) {
 
+		uint64_t timestamp;
+
 		if (tmr_jiffies() < ts) {
 			sys_msleep(4);
 			continue;
@@ -127,9 +130,11 @@ static void *read_thread(void *arg)
 		if (!buf)
 			continue;
 
+		timestamp = ts * VIDEO_TIMEBASE / 1000;
+
 		ts += (1000/st->fps);
 
-		call_frame_handler(st, buf);
+		call_frame_handler(st, buf, timestamp);
 	}
 
 	return NULL;

--- a/src/video.c
+++ b/src/video.c
@@ -453,9 +453,12 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame)
  *
  * @note This function has REAL-TIME properties
  */
-static void vidsrc_frame_handler(struct vidframe *frame, void *arg)
+static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
+				 void *arg)
 {
 	struct vtx *vtx = arg;
+
+	/* XXX: save timestamp(s) and pass to encoder */
 
 	++vtx->frames;
 

--- a/src/vidutil.c
+++ b/src/vidutil.c
@@ -50,3 +50,9 @@ double video_calc_seconds(uint64_t rtp_ts)
 
 	return timestamp;
 }
+
+
+double video_timestamp_to_seconds(uint64_t timestamp)
+{
+	return (double)timestamp / (double)VIDEO_TIMEBASE;
+}

--- a/test/mock/mock_vidsrc.c
+++ b/test/mock/mock_vidsrc.c
@@ -14,6 +14,7 @@ struct vidsrc_st {
 
 	struct vidframe *frame;
 	struct tmr tmr;
+	uint64_t timestamp;
 	double fps;
 	vidsrc_frame_h *frameh;
 	void *arg;
@@ -27,7 +28,9 @@ static void tmr_handler(void *arg)
 	tmr_start(&st->tmr, 1000/st->fps, tmr_handler, st);
 
 	if (st->frameh)
-		st->frameh(st->frame, st->arg);
+		st->frameh(st->frame, st->timestamp, st->arg);
+
+	st->timestamp += VIDEO_TIMEBASE / st->fps;
 }
 
 


### PR DESCRIPTION
This PR adds a new _timestamp_ field to the vidsrc frame handler.

Background: The video encoding pipeline currently does not use the timestamp
from the video source at all. Instead the video codecs have a frame counter,
that is used together with `fps` to calculate the RTP timestamp.
This solution is not accurate, and I want to change it so that the exact timestamp
for each video frame (coming from the source) will be transported all the way
through the video pipeline, which currently looks like this:

1. Video source
2. Video filters
3. Video encoder and packetizer
4. RTP sending

For timestamp format the following units was considered:

* double float (seconds)
* uint64_t timestamp (milliseconds)
* uint64_t timestamp (microseconds)
* int64_t pts, Presentation Timestamp in timebase units
* uint64_t rtp_ts (RTP Timestamp in 90000Hz units)
* struct timestamp with value, duration and timebase units

For now the timestamp is `uint64_t timestamp` and the unit is defined
in the `VIDEO_TIMEBASE` macro (currently set to 1 million which means
in units of 1 microseconds). This type is subject to discussion.

| Vidsrc module | Timestamp units                |
| ------------- | ------------------------------ |
| avcapture     | double float seconds           |
| avformat      | int64_t pts in time_base units |
| cairo         | uint64_t milliseconds          |
| dshow         | ?                              |
| fakevideo     | uint64_t milliseconds          |
| qtcapture     |                                |
| rst           | uint64_t milliseconds          |
| v4l           | ?                              |
| v4l2          | struct timeval                 |
| vidbridge     | opaque, same as vidisp         |
| x11grab       | uint64_t milliseconds          |
