### PR TITLE
Videnc add timestamp

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1051,7 +1051,7 @@ void  video_set_devicename(struct video *v, const char *src, const char *disp);
 void  video_encoder_cycle(struct video *video);
 int   video_debug(struct re_printf *pf, const struct video *v);
 uint64_t video_calc_rtp_timestamp(int64_t pts, double fps);
-uint64_t video_calc_rtp_timestamp_fix(int64_t pts);
+uint64_t video_calc_rtp_timestamp_fix(uint64_t timestamp);
 double video_calc_seconds(uint64_t rtp_ts);
 struct stream *video_strm(const struct video *v);
 double video_timestamp_to_seconds(uint64_t timestamp);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -937,8 +937,10 @@ typedef int (videnc_update_h)(struct videnc_state **vesp,
 			      const struct vidcodec *vc,
 			      struct videnc_param *prm, const char *fmtp,
 			      videnc_packet_h *pkth, void *arg);
+
 typedef int (videnc_encode_h)(struct videnc_state *ves, bool update,
-			      const struct vidframe *frame);
+			      const struct vidframe *frame,
+			      uint64_t timestamp);
 
 typedef int (viddec_update_h)(struct viddec_state **vdsp,
 			      const struct vidcodec *vc, const char *fmtp);
@@ -1049,6 +1051,7 @@ void  video_set_devicename(struct video *v, const char *src, const char *disp);
 void  video_encoder_cycle(struct video *video);
 int   video_debug(struct re_printf *pf, const struct video *v);
 uint64_t video_calc_rtp_timestamp(int64_t pts, double fps);
+uint64_t video_calc_rtp_timestamp_fix(int64_t pts);
 double video_calc_seconds(uint64_t rtp_ts);
 struct stream *video_strm(const struct video *v);
 double video_timestamp_to_seconds(uint64_t timestamp);

--- a/modules/av1/av1.h
+++ b/modules/av1/av1.h
@@ -10,7 +10,7 @@ int av1_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
 		      videnc_packet_h *pkth, void *arg);
 int av1_encode(struct videnc_state *ves, bool update,
-	       const struct vidframe *frame);
+	       const struct vidframe *frame, uint64_t timestamp);
 
 
 /* Decode */

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -38,10 +38,11 @@ struct videnc_state;
 int encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		  struct videnc_param *prm, const char *fmtp,
 		  videnc_packet_h *pkth, void *arg);
-int encode(struct videnc_state *st, bool update, const struct vidframe *frame);
+int encode(struct videnc_state *st, bool update, const struct vidframe *frame,
+	   uint64_t timestamp);
 #ifdef USE_X264
 int encode_x264(struct videnc_state *st, bool update,
-		const struct vidframe *frame);
+		const struct vidframe *frame, uint64_t timestamp);
 #endif
 
 

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -42,7 +42,6 @@ struct videnc_state {
 	AVFrame *pict;
 	struct mbuf *mb;
 	size_t sz_max; /* todo: figure out proper buffer size */
-	int64_t pts;
 	struct mbuf *mb_frag;
 	struct videnc_param encprm;
 	struct vidsz encsize;
@@ -556,13 +555,14 @@ int encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 
 #ifdef USE_X264
 int encode_x264(struct videnc_state *st, bool update,
-		const struct vidframe *frame)
+		const struct vidframe *frame, uint64_t timestamp)
 {
 	x264_picture_t pic_in, pic_out;
 	x264_nal_t *nal;
 	int i_nal;
 	int i, err, ret;
 	int csp, pln;
+	int64_t input_pts;
 	uint64_t ts;
 
 	if (!st || !frame)
@@ -607,9 +607,17 @@ int encode_x264(struct videnc_state *st, bool update,
 
 	x264_picture_init(&pic_in);
 
+	/*
+	 * We use the video source timestamp as PTS.
+	 * Since the PTS is in time_base units (derived from FPS) and
+	 * the input and output has the same units, this should work
+	 * fine, as long as the real FPS is less than the MAX FPS.
+	 */
+	input_pts = timestamp;
+
 	pic_in.i_type = update ? X264_TYPE_IDR : X264_TYPE_AUTO;
 	pic_in.i_qpplus1 = 0;
-	pic_in.i_pts = ++st->pts;
+	pic_in.i_pts = input_pts;
 
 	pic_in.img.i_csp = csp;
 	pic_in.img.i_plane = pln;
@@ -625,7 +633,7 @@ int encode_x264(struct videnc_state *st, bool update,
 	if (i_nal == 0)
 		return 0;
 
-	ts = video_calc_rtp_timestamp(pic_out.i_pts, st->encprm.fps);
+	ts = video_calc_rtp_timestamp_fix(pic_out.i_pts);
 
 	err = 0;
 	for (i=0; i<i_nal && !err; i++) {
@@ -660,10 +668,12 @@ int encode_x264(struct videnc_state *st, bool update,
 #endif
 
 
-int encode(struct videnc_state *st, bool update, const struct vidframe *frame)
+int encode(struct videnc_state *st, bool update, const struct vidframe *frame,
+	   uint64_t timestamp)
 {
 	int i, err, ret;
 	int pix_fmt;
+	int64_t pts;
 	uint64_t ts;
 
 	if (!st || !frame)
@@ -702,7 +712,7 @@ int encode(struct videnc_state *st, bool update, const struct vidframe *frame)
 		st->pict->data[i]     = frame->data[i];
 		st->pict->linesize[i] = frame->linesize[i];
 	}
-	st->pict->pts = st->pts++;
+	st->pict->pts = timestamp;
 	if (update) {
 		debug("avcodec: encoder picture update\n");
 		st->pict->key_frame = 1;
@@ -737,7 +747,7 @@ int encode(struct videnc_state *st, bool update, const struct vidframe *frame)
 			return 0;
 		}
 
-		ts = video_calc_rtp_timestamp(pkt->dts, st->encprm.fps);
+		pts = pkt->dts;
 
 		err = mbuf_write_mem(st->mb, pkt->data, pkt->size);
 		st->mb->pos = 0;
@@ -766,7 +776,7 @@ int encode(struct videnc_state *st, bool update, const struct vidframe *frame)
 
 		mbuf_set_end(st->mb, avpkt.size);
 
-		ts = video_calc_rtp_timestamp(avpkt.dts, st->encprm.fps);
+		pts = avpkt.dts;
 
 	} while (0);
 #else
@@ -784,8 +794,10 @@ int encode(struct videnc_state *st, bool update, const struct vidframe *frame)
 
 	mbuf_set_end(st->mb, ret);
 
-	ts = video_calc_rtp_timestamp(st->pict->pts, st->encprm.fps);
+	pts = st->pict->pts;
 #endif
+
+	ts = video_calc_rtp_timestamp_fix(pts);
 
 	switch (st->codec_id) {
 

--- a/modules/gst_video1/encode.c
+++ b/modules/gst_video1/encode.c
@@ -471,7 +471,8 @@ int gst_video1_encoder_set(struct videnc_state **stp,
 /*
  * couple gstreamer tightly by lock-stepping
  */
-static int pipeline_push(struct videnc_state *st, const struct vidframe *frame)
+static int pipeline_push(struct videnc_state *st, const struct vidframe *frame,
+			 uint64_t timestamp)
 {
 	GstBuffer *buffer;
 	uint8_t *data;
@@ -531,6 +532,9 @@ static int pipeline_push(struct videnc_state *st, const struct vidframe *frame)
 				 gst_memory_new_wrapped (0, data, size, 0,
 							 size, data, g_free));
 
+	/* convert timestamp to nanoseconds */
+	buffer->pts = timestamp * 1000000000ULL / VIDEO_TIMEBASE;
+
 	/*
 	 * Push data and EOS into gstreamer.
 	 */
@@ -577,7 +581,7 @@ static int pipeline_push(struct videnc_state *st, const struct vidframe *frame)
 
 
 int gst_video1_encode(struct videnc_state *st, bool update,
-		     const struct vidframe *frame)
+		      const struct vidframe *frame, uint64_t timestamp)
 {
 	int err;
 
@@ -607,7 +611,7 @@ int gst_video1_encode(struct videnc_state *st, bool update,
 	 * Push frame into pipeline.
 	 * Function call will return once frame has been processed completely.
 	 */
-	err = pipeline_push(st, frame);
+	err = pipeline_push(st, frame, timestamp);
 
 	return err;
 }

--- a/modules/gst_video1/gst_video.h
+++ b/modules/gst_video1/gst_video.h
@@ -14,7 +14,7 @@ int gst_video1_encoder_set(struct videnc_state **stp,
 			  struct videnc_param *prm, const char *fmtp,
 			  videnc_packet_h *pkth, void *arg);
 int gst_video1_encode(struct videnc_state *st, bool update,
-		     const struct vidframe *frame);
+		      const struct vidframe *frame, uint64_t timestamp);
 
 
 /* SDP */

--- a/modules/h265/decode.c
+++ b/modules/h265/decode.c
@@ -329,6 +329,14 @@ int h265_decode(struct viddec_state *vds, struct vidframe *frame,
 	frame->size.h = vds->ctx->height;
 	frame->fmt    = fmt;
 
+#if 1
+	/* get the framerate of the decoded bitstream */
+	double fps;
+	fps = av_q2d(vds->ctx->framerate);
+	re_printf("h265: current decoder framerate"
+	      " is %.2f fps\n", fps);
+#endif
+
  out:
 	mbuf_rewind(vds->mb);
 	vds->frag = false;

--- a/modules/h265/decode.c
+++ b/modules/h265/decode.c
@@ -329,14 +329,6 @@ int h265_decode(struct viddec_state *vds, struct vidframe *frame,
 	frame->size.h = vds->ctx->height;
 	frame->fmt    = fmt;
 
-#if 1
-	/* get the framerate of the decoded bitstream */
-	double fps;
-	fps = av_q2d(vds->ctx->framerate);
-	re_printf("h265: current decoder framerate"
-	      " is %.2f fps\n", fps);
-#endif
-
  out:
 	mbuf_rewind(vds->mb);
 	vds->frag = false;

--- a/modules/h265/h265.h
+++ b/modules/h265/h265.h
@@ -61,7 +61,7 @@ int h265_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		       struct videnc_param *prm, const char *fmtp,
 		       videnc_packet_h *pkth, void *arg);
 int h265_encode(struct videnc_state *ves, bool update,
-		const struct vidframe *frame);
+		const struct vidframe *frame, uint64_t timestamp);
 
 /* decoder */
 int h265_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,

--- a/modules/v4l2_codec/v4l2_codec.c
+++ b/modules/v4l2_codec/v4l2_codec.c
@@ -444,11 +444,12 @@ static int encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 
 /* note: dummy function, the input is unused */
 static int encode_packet(struct videnc_state *st, bool update,
-			 const struct vidframe *frame)
+			 const struct vidframe *frame, uint64_t timestamp)
 {
 	(void)st;
 	(void)update;
 	(void)frame;
+	(void)timestamp;
 
 	/*
 	 * XXX: add support for KEY frame requests

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -150,7 +150,6 @@ static int packet_handler(bool marker, uint64_t rtp_ts,
 	struct mbuf *mb;
 	bool intra;
 	int err = 0;
-	(void)rtp_ts;
 
 	++vl->stats.enc_packets;
 	vl->stats.enc_bytes += (hdr_len + pld_len);
@@ -269,7 +268,8 @@ static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
 	}
 
 	if (vl->vc_enc && vl->enc) {
-		err = vl->vc_enc->ench(vl->enc, false, frame);
+
+		err = vl->vc_enc->ench(vl->enc, false, frame, timestamp);
 		if (err) {
 			warning("vidloop: encoder error (%m)\n", err);
 			goto out;

--- a/modules/vp8/encode.c
+++ b/modules/vp8/encode.c
@@ -21,7 +21,6 @@ enum {
 struct videnc_state {
 	vpx_codec_ctx_t ctx;
 	struct vidsz size;
-	vpx_codec_pts_t pts;
 	unsigned fps;
 	unsigned bitrate;
 	unsigned pktsize;
@@ -187,7 +186,7 @@ static inline int packetize(bool marker, const uint8_t *buf, size_t len,
 
 
 int vp8_encode(struct videnc_state *ves, bool update,
-		const struct vidframe *frame)
+	       const struct vidframe *frame, uint64_t timestamp)
 {
 	vpx_enc_frame_flags_t flags = 0;
 	vpx_codec_iter_t iter = NULL;
@@ -223,7 +222,7 @@ int vp8_encode(struct videnc_state *ves, bool update,
 		img.planes[i] = frame->data[i];
 	}
 
-	res = vpx_codec_encode(&ves->ctx, &img, ves->pts++, 1,
+	res = vpx_codec_encode(&ves->ctx, &img, timestamp, 1,
 			       flags, VPX_DL_REALTIME);
 	if (res) {
 		warning("vp8: enc error: %s\n", vpx_codec_err_to_string(res));
@@ -256,7 +255,10 @@ int vp8_encode(struct videnc_state *ves, bool update,
 			partid = pkt->data.frame.partition_id;
 #endif
 
-		ts = video_calc_rtp_timestamp(pkt->data.frame.pts, ves->fps);
+		/*
+		 * convert PTS to RTP Timestamp
+		 */
+		ts =  video_calc_rtp_timestamp_fix(pkt->data.frame.pts);
 
 		err = packetize(marker,
 				pkt->data.frame.buf,

--- a/modules/vp8/vp8.h
+++ b/modules/vp8/vp8.h
@@ -14,7 +14,7 @@ int vp8_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
 		      videnc_packet_h *pkth, void *arg);
 int vp8_encode(struct videnc_state *ves, bool update,
-	       const struct vidframe *frame);
+	       const struct vidframe *frame, uint64_t timestamp);
 
 
 /* Decode */

--- a/modules/vp9/vp9.h
+++ b/modules/vp9/vp9.h
@@ -14,7 +14,7 @@ int vp9_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
 		      videnc_packet_h *pkth, void *arg);
 int vp9_encode(struct videnc_state *ves, bool update,
-	       const struct vidframe *frame);
+	       const struct vidframe *frame, uint64_t timestamp);
 
 
 /* Decode */

--- a/src/video.c
+++ b/src/video.c
@@ -383,7 +383,8 @@ static int packet_handler(bool marker, uint64_t ts,
  * @param vtx   Video transmit object
  * @param frame Video frame to send
  */
-static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame)
+static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
+			    uint64_t timestamp)
 {
 	struct le *le;
 	int err = 0;
@@ -437,7 +438,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame)
 		return;
 
 	/* Encode the whole picture frame */
-	err = vtx->vc->ench(vtx->enc, vtx->picup, frame);
+	err = vtx->vc->ench(vtx->enc, vtx->picup, frame, timestamp);
 	if (err)
 		return;
 
@@ -473,7 +474,7 @@ static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
 		return;
 
 	/* Encode and send */
-	encode_rtp_send(vtx, frame);
+	encode_rtp_send(vtx, frame, timestamp);
 	vtx->muted_frames++;
 }
 

--- a/src/vidutil.c
+++ b/src/vidutil.c
@@ -63,3 +63,16 @@ double video_timestamp_to_seconds(uint64_t timestamp)
 {
 	return (double)timestamp / (double)VIDEO_TIMEBASE;
 }
+
+
+/*
+ * Convert PTS to RTP Timestamp
+ */
+uint64_t video_calc_rtp_timestamp_fix(int64_t pts)
+{
+	uint64_t rtp_ts;
+
+	rtp_ts = pts * VIDEO_SRATE / VIDEO_TIMEBASE;
+
+	return rtp_ts;
+}

--- a/src/vidutil.c
+++ b/src/vidutil.c
@@ -65,14 +65,18 @@ double video_timestamp_to_seconds(uint64_t timestamp)
 }
 
 
-/*
- * Convert PTS to RTP Timestamp
+/**
+ * Calculate the RTP timestamp from a timestamp in VIDEO_TIMEBASE units
+ *
+ * @param timestamp Timestamp in VIDEO_TIMEBASE units
+ *
+ * @return Extended RTP Timestamp
  */
-uint64_t video_calc_rtp_timestamp_fix(int64_t pts)
+uint64_t video_calc_rtp_timestamp_fix(uint64_t timestamp)
 {
 	uint64_t rtp_ts;
 
-	rtp_ts = pts * VIDEO_SRATE / VIDEO_TIMEBASE;
+	rtp_ts = timestamp * VIDEO_SRATE / VIDEO_TIMEBASE;
 
 	return rtp_ts;
 }

--- a/test/mock/mock_vidcodec.c
+++ b/test/mock/mock_vidcodec.c
@@ -21,7 +21,6 @@ struct hdr {
 };
 
 struct videnc_state {
-	int64_t pts;
 	double fps;
 	videnc_packet_h *pkth;
 	void *arg;
@@ -84,7 +83,7 @@ static int mock_encode_update(struct videnc_state **vesp,
 
 
 static int mock_encode(struct videnc_state *ves, bool update,
-		       const struct vidframe *frame)
+		       const struct vidframe *frame, uint64_t timestamp)
 {
 	struct mbuf *hdr;
 	uint8_t payload[2] = {0,0};
@@ -103,7 +102,7 @@ static int mock_encode(struct videnc_state *ves, bool update,
 	if (err)
 		goto out;
 
-	rtp_ts = video_calc_rtp_timestamp(++ves->pts, ves->fps);
+	rtp_ts = video_calc_rtp_timestamp_fix(timestamp);
 
 	err = ves->pkth(true, rtp_ts, hdr->buf, hdr->end,
 			payload, sizeof(payload), ves->arg);


### PR DESCRIPTION
This PR adds a new timestamp parameter to the video encoder API.

The unit is the same as the vidsrc API (defined in the VIDEO_TIMEBASE macro).

