### PR TITLE
added menc event handling and replaced zrtp module zrtp command with two commands

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -58,6 +58,7 @@ int account_set_auth_user(struct account *acc, const char *user);
 int account_set_auth_pass(struct account *acc, const char *pass);
 int account_set_outbound(struct account *acc, const char *ob, unsigned ix);
 int account_set_display_name(struct account *acc, const char *dname);
+int account_set_regint(struct account *acc, uint32_t regint);
 int account_auth(const struct account *acc, char **username, char **password,
 		 const char *realm);
 struct list *account_aucodecl(const struct account *acc);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -103,6 +103,13 @@ enum call_event {
 	CALL_EVENT_CLOSED,
 	CALL_EVENT_TRANSFER,
 	CALL_EVENT_TRANSFER_FAILED,
+	CALL_EVENT_MENC,
+};
+
+enum menc_event {
+	MENC_EVENT_SECURE,
+	MENC_EVENT_VERIFY_REQUEST,
+	MENC_EVENT_PEER_VERIFIED,
 };
 
 struct call;
@@ -521,8 +528,11 @@ struct menc_media;
 
 typedef void (menc_error_h)(int err, void *arg);
 
+typedef void (menc_event_h)(enum menc_event event, const char *prm, void *arg);
+
 typedef int  (menc_sess_h)(struct menc_sess **sessp, struct sdp_session *sdp,
-			   bool offerer, menc_error_h *errorh, void *arg);
+			   bool offerer, menc_event_h *eventh,
+                           menc_error_h *errorh, void *arg);
 
 typedef int  (menc_media_h)(struct menc_media **mp, struct menc_sess *sess,
 			    struct rtp_sock *rtp, int proto,
@@ -603,6 +613,7 @@ enum ua_event {
 	UA_EVENT_CALL_DTMF_START,
 	UA_EVENT_CALL_DTMF_END,
 	UA_EVENT_CALL_RTCP,
+	UA_EVENT_CALL_MENC,
 
 	UA_EVENT_MAX,
 };

--- a/modules/dtls_srtp/dtls_srtp.c
+++ b/modules/dtls_srtp/dtls_srtp.c
@@ -49,6 +49,7 @@
 struct menc_sess {
 	struct sdp_session *sdp;
 	bool offerer;
+	menc_event_h *eventh;
 	menc_error_h *errorh;
 	void *arg;
 };
@@ -151,7 +152,8 @@ static bool verify_fingerprint(const struct sdp_session *sess,
 
 static int session_alloc(struct menc_sess **sessp,
 			 struct sdp_session *sdp, bool offerer,
-			 menc_error_h *errorh, void *arg)
+			 menc_event_h *eventh, menc_error_h *errorh,
+			 void *arg)
 {
 	struct menc_sess *sess;
 	int err;
@@ -165,6 +167,7 @@ static int session_alloc(struct menc_sess **sessp,
 
 	sess->sdp     = mem_ref(sdp);
 	sess->offerer = offerer;
+	sess->eventh  = eventh;
 	sess->errorh  = errorh;
 	sess->arg     = arg;
 

--- a/modules/gzrtp/gzrtp.cpp
+++ b/modules/gzrtp/gzrtp.cpp
@@ -69,10 +69,12 @@ static void media_destructor(void *arg)
 
 
 static int session_alloc(struct menc_sess **sessp, struct sdp_session *sdp,
-                         bool offerer, menc_error_h *errorh, void *arg)
+			 bool offerer, menc_event_h *eventh,
+			 menc_error_h *errorh, void *arg)
 {
 	struct menc_sess *st;
 	(void)offerer;
+	(void)eventh;
 	(void)errorh;
 	(void)arg;
 	int err = 0;

--- a/src/account.c
+++ b/src/account.c
@@ -475,6 +475,17 @@ int account_set_outbound(struct account *acc, const char *ob, unsigned ix)
 }
 
 
+int account_set_regint(struct account *acc, uint32_t regint)
+{
+	if (!acc)
+		return EINVAL;
+
+	acc->regint = regint;
+
+	return 0;
+}
+
+
 /**
  * Sets the displayed name. Pass null in dname to disable display name
  *

--- a/src/call.c
+++ b/src/call.c
@@ -450,6 +450,20 @@ static void menc_error_handler(int err, void *arg)
 }
 
 
+static void menc_event_handler(const enum menc_event event,
+			       const char *prm, void *arg)
+{
+	struct call *call = arg;
+	MAGIC_CHECK(call);
+
+	if (strlen(prm) > 0)
+		call_event_handler(call, CALL_EVENT_MENC, "%u,%s", event,
+				   prm);
+	else
+		call_event_handler(call, CALL_EVENT_MENC, "%u", event);
+}
+
+
 static void stream_error_handler(struct stream *strm, int err, void *arg)
 {
 	struct call *call = arg;
@@ -582,8 +596,9 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	if (acc->menc) {
 		if (acc->menc->sessh) {
 			err = acc->menc->sessh(&call->mencs, call->sdp,
-						!got_offer,
-						menc_error_handler, call);
+					       !got_offer,
+					       menc_event_handler,
+					       menc_error_handler, call);
 			if (err) {
 				warning("call: mediaenc session: %m\n", err);
 				goto out;

--- a/src/event.c
+++ b/src/event.c
@@ -32,6 +32,7 @@ static const char *event_class_name(enum ua_event ev)
 	case UA_EVENT_CALL_DTMF_START:
 	case UA_EVENT_CALL_DTMF_END:
 	case UA_EVENT_CALL_RTCP:
+	case UA_EVENT_CALL_MENC:
 		return "call";
 
 	default:
@@ -174,6 +175,7 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_CALL_DTMF_START:      return "CALL_DTMF_START";
 	case UA_EVENT_CALL_DTMF_END:        return "CALL_DTMF_END";
 	case UA_EVENT_CALL_RTCP:            return "CALL_RTCP";
+	case UA_EVENT_CALL_MENC:            return "CALL_MENC";
 	default: return "?";
 	}
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -388,7 +388,11 @@ static void call_event_handler(struct call *call, enum call_event ev,
 	case CALL_EVENT_TRANSFER_FAILED:
 		ua_event(ua, UA_EVENT_CALL_TRANSFER_FAILED, call, str);
 		break;
-	}
+
+	case CALL_EVENT_MENC:
+		ua_event(ua, UA_EVENT_CALL_MENC, call, str);
+		break;
+        }
 }
 
 


### PR DESCRIPTION
Based on Alfred's suggestion, added menc_event handler. Call event is still CALL_EVENT_MENC and the type is in the parameter.  Should there be separate CALL_EVENT_SECURE, CALL_EVENT_VERIFY_REQUEST, and CALL_EVENT_PEER_VERIFIED events instead?

-- Juha