### PR TITLE
do not default auth_user to sip uri userpart, but leave unset instead

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -322,8 +322,6 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 
 	if (0 == msg_param_decode(&aor->params, "auth_user", &auth_user))
 		err |= pl_strdup(&acc->auth_user, &auth_user);
-	else
-		err |= pl_strdup(&acc->auth_user, &aor->uri.user);
 
 	if (pl_isset(&aor->dname))
 		err |= pl_strdup(&acc->dispname, &aor->dname);


### PR DESCRIPTION
auth_user may not be needed at all or it may not be the same as sip uri
userpart.  for example, sip uri userpart may be telephone number and
auth_user may be userid.