### PR TITLE
added account_set_audio_codecs API function

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -60,6 +60,7 @@ int account_set_outbound(struct account *acc, const char *ob, unsigned ix);
 int account_set_display_name(struct account *acc, const char *dname);
 int account_set_regint(struct account *acc, uint32_t regint);
 int account_set_mediaenc(struct account *acc, const char *mediaenc);
+int account_set_audio_codecs(struct account *acc, const char *codecs);
 int account_auth(const struct account *acc, char **username, char **password,
 		 const char *realm);
 struct list *account_aucodecl(const struct account *acc);

--- a/src/account.c
+++ b/src/account.c
@@ -231,6 +231,8 @@ static int audio_codecs_decode(struct account *acc, const struct pl *prm)
 			}
 
 			/* NOTE: static list with references to aucodec */
+                        acc->acv[i].prev = acc->acv[i].next = NULL;
+                        acc->acv[i].list = NULL;
 			list_append(&acc->aucodecl, &acc->acv[i++], ac);
 
 			if (i >= ARRAY_SIZE(acc->acv))
@@ -503,6 +505,31 @@ int account_set_mediaenc(struct account *acc, const char *mencid)
 		return str_dup(&acc->mencid, mencid);
 
 	return 0;
+}
+
+
+/**
+ * Sets audio codecs
+ *
+ * @param acc      User-Agent account
+ * @param codecs   Comma separed list of audio codecs (NULL to disable)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int account_set_audio_codecs(struct account *acc, const char *codecs)
+{
+	char buf[256];
+	struct pl pl;
+
+	if (!codecs) {
+		list_clear(&acc->aucodecl);
+		return 0;
+	}
+
+	re_snprintf(buf, sizeof buf, ";audio_codecs=%s", codecs);
+	pl_set_str(&pl, buf);
+
+	return audio_codecs_decode(acc, &pl);
 }
 
 

--- a/src/account.c
+++ b/src/account.c
@@ -231,8 +231,6 @@ static int audio_codecs_decode(struct account *acc, const struct pl *prm)
 			}
 
 			/* NOTE: static list with references to aucodec */
-                        acc->acv[i].prev = acc->acv[i].next = NULL;
-                        acc->acv[i].list = NULL;
 			list_append(&acc->aucodecl, &acc->acv[i++], ac);
 
 			if (i >= ARRAY_SIZE(acc->acv))
@@ -521,15 +519,18 @@ int account_set_audio_codecs(struct account *acc, const char *codecs)
 	char buf[256];
 	struct pl pl;
 
-	if (!codecs) {
-		list_clear(&acc->aucodecl);
-		return 0;
+	if (!acc)
+		return EINVAL;
+
+	list_clear(&acc->aucodecl);
+
+	if (codecs) {
+		re_snprintf(buf, sizeof buf, ";audio_codecs=%s", codecs);
+		pl_set_str(&pl, buf);
+		return audio_codecs_decode(acc, &pl);
 	}
 
-	re_snprintf(buf, sizeof buf, ";audio_codecs=%s", codecs);
-	pl_set_str(&pl, buf);
-
-	return audio_codecs_decode(acc, &pl);
+	return 0;
 }
 
 


### PR DESCRIPTION
for ease of use and implementation, audio codecs argument is a string
containing comma separated list of codecs like in accounts file