### PR TITLE
dont call deprecated ffmpeg functions

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -197,7 +197,9 @@ static int module_init(void)
 	avcodec_init();
 #endif
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	avcodec_register_all();
+#endif
 
 	if (0 == conf_get_str(conf_cur(), "avcodec_h264dec",
 			      h264dec, sizeof(h264dec))) {

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -422,14 +422,18 @@ static int alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 static int module_init(void)
 {
 	/* register all codecs, demux and protocols */
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	avcodec_register_all();
+#endif
 	avdevice_register_all();
 
 #if LIBAVFORMAT_VERSION_INT >= ((53<<16) + (13<<8) + 0)
 	avformat_network_init();
 #endif
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	av_register_all();
+#endif
 
 	return vidsrc_register(&mod_avf, baresip_vidsrcl(),
 			       "avformat", alloc, NULL);

--- a/modules/h265/h265.c
+++ b/modules/h265/h265.c
@@ -43,7 +43,9 @@ static int module_init(void)
 	info("h265: using x265 %s %s\n",
 	     x265_version_str, x265_build_info_str);
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
 	avcodec_register_all();
+#endif
 
 	vidcodec_register(baresip_vidcodecl(), &h265);
 


### PR DESCRIPTION
fixes warnings when compiled with ffmpeg 4.0