### PR TITLE
"net_interface" config option can take both adapter-name or IP-address.

### DIFF
--- a/mk/win32/baresip.vcxproj
+++ b/mk/win32/baresip.vcxproj
@@ -193,6 +193,7 @@
     <ClCompile Include="..\..\src\sdp.c" />
     <ClCompile Include="..\..\src\sipreq.c" />
     <ClCompile Include="..\..\src\stream.c" />
+    <ClCompile Include="..\..\src\timer.c" />
     <ClCompile Include="..\..\src\ua.c" />
     <ClCompile Include="..\..\src\ui.c" />
     <ClCompile Include="..\..\src\vidcodec.c" />

--- a/mk/win32/baresip.vcxproj.filters
+++ b/mk/win32/baresip.vcxproj.filters
@@ -367,5 +367,8 @@
     <ClCompile Include="..\..\src\aulevel.c" />
     <ClCompile Include="..\..\src\vidutil.c" />
     <ClCompile Include="..\..\src\event.c" />
+    <ClCompile Include="..\..\src\timer.c">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hello
According to issue [#403](https://github.com/alfredh/baresip/issues/403)
Now ```net_interface``` config option can take both adapter-name or IP-address.

Also MSVS project was updated (adding file timer.c to compilation list)

Here is baresip selftest output:

> running baresip selftest version 0.5.9 with 33 tests
[ RUN      ] test_account
[       OK ]
[ RUN      ] test_aulevel
[       OK ]
[ RUN      ] test_call_af_mismatch
[       OK ]
[ RUN      ] test_call_answer
[       OK ]
[ RUN      ] test_call_answer_hangup_a
[       OK ]
[ RUN      ] test_call_answer_hangup_b
[       OK ]
[ RUN      ] test_call_reject
[       OK ]
[ RUN      ] test_call_rtp_timeout
[       OK ]
[ RUN      ] test_call_mediaenc
[       OK ]
[ RUN      ] test_call_multiple
[       OK ]
[ RUN      ] test_call_max
[       OK ]
[ RUN      ] test_call_dtmf
[       OK ]
[ RUN      ] test_call_aulevel
[       OK ]
[ RUN      ] test_call_progress
[       OK ]
[ RUN      ] test_call_format_float
[       OK ]
[ RUN      ] test_call_video
[       OK ]
[ RUN      ] test_video
[       OK ]
[ RUN      ] test_cmd
[       OK ]
[ RUN      ] test_cmd_long
[       OK ]
[ RUN      ] test_contact
[       OK ]
[ RUN      ] test_cplusplus
[       OK ]
[ RUN      ] test_event
[       OK ]
[ RUN      ] test_message
[       OK ]
[ RUN      ] test_mos
[       OK ]
[ RUN      ] test_network
[       OK ]
[ RUN      ] test_play
[       OK ]
[ RUN      ] test_ua_alloc
[       OK ]
[ RUN      ] test_ua_options
[       OK ]
[ RUN      ] test_ua_register
[       OK ]
[ RUN      ] test_ua_register_dns
[       OK ]
[ RUN      ] test_ua_register_auth
[       OK ]
[ RUN      ] test_ua_register_auth_dns
[       OK ]
[ RUN      ] test_uag_find_param
[       OK ]
OK. 33 tests passed successfully
