### PR TITLE
aufilt: add pointer to "struct audio"

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -468,12 +468,14 @@ struct aufilt_prm {
 };
 
 typedef int (aufilt_encupd_h)(struct aufilt_enc_st **stp, void **ctx,
-			      const struct aufilt *af, struct aufilt_prm *prm);
+			      const struct aufilt *af, struct aufilt_prm *prm,
+			      const struct audio *au);
 typedef int (aufilt_encode_h)(struct aufilt_enc_st *st,
 			      int16_t *sampv, size_t *sampc);
 
 typedef int (aufilt_decupd_h)(struct aufilt_dec_st **stp, void **ctx,
-			      const struct aufilt *af, struct aufilt_prm *prm);
+			      const struct aufilt *af, struct aufilt_prm *prm,
+			      const struct audio *au);
 typedef int (aufilt_decode_h)(struct aufilt_dec_st *st,
 			      int16_t *sampv, size_t *sampc);
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -885,11 +885,13 @@ static int16_t calc_avg_s16(const int16_t *sampv, size_t sampc)
 
 
 static int vu_encode_update(struct aufilt_enc_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			    const struct aufilt *af, struct aufilt_prm *prm,
+			    const struct audio *au)
 {
 	struct vumeter_enc *st;
 	(void)ctx;
 	(void)prm;
+	(void)au;
 
 	if (!stp || !af)
 		return EINVAL;
@@ -912,11 +914,13 @@ static int vu_encode_update(struct aufilt_enc_st **stp, void **ctx,
 
 
 static int vu_decode_update(struct aufilt_dec_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			    const struct aufilt *af, struct aufilt_prm *prm,
+			    const struct audio *au)
 {
 	struct vumeter_dec *st;
 	(void)ctx;
 	(void)prm;
+	(void)au;
 
 	if (!stp || !af)
 		return EINVAL;

--- a/modules/plc/plc.c
+++ b/modules/plc/plc.c
@@ -35,12 +35,14 @@ static void destructor(void *arg)
 
 
 static int update(struct aufilt_dec_st **stp, void **ctx,
-		  const struct aufilt *af, struct aufilt_prm *prm)
+		  const struct aufilt *af, struct aufilt_prm *prm,
+		  const struct audio *au)
 {
 	struct plc_st *st;
 	int err = 0;
 	(void)ctx;
 	(void)af;
+	(void)au;
 
 	if (!stp || !prm)
 		return EINVAL;

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -99,12 +99,14 @@ static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
 
 
 static int encode_update(struct aufilt_enc_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct sndfile_enc *st;
 	int err = 0;
 	(void)ctx;
 	(void)af;
+	(void)au;
 
 	st = mem_zalloc(sizeof(*st), enc_destructor);
 	if (!st)
@@ -124,12 +126,14 @@ static int encode_update(struct aufilt_enc_st **stp, void **ctx,
 
 
 static int decode_update(struct aufilt_dec_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct sndfile_dec *st;
 	int err = 0;
 	(void)ctx;
 	(void)af;
+	(void)au;
 
 	st = mem_zalloc(sizeof(*st), dec_destructor);
 	if (!st)

--- a/modules/speex_aec/speex_aec.c
+++ b/modules/speex_aec/speex_aec.c
@@ -117,10 +117,12 @@ static int aec_alloc(struct speex_st **stp, void **ctx, struct aufilt_prm *prm)
 
 
 static int encode_update(struct aufilt_enc_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct enc_st *st;
 	int err;
+	(void)au;
 
 	if (!stp || !ctx || !af || !prm)
 		return EINVAL;
@@ -144,10 +146,12 @@ static int encode_update(struct aufilt_enc_st **stp, void **ctx,
 
 
 static int decode_update(struct aufilt_dec_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct dec_st *st;
 	int err;
+	(void)au;
 
 	if (!stp || !ctx || !af || !prm)
 		return EINVAL;

--- a/modules/speex_pp/speex_pp.c
+++ b/modules/speex_pp/speex_pp.c
@@ -52,11 +52,13 @@ static void speexpp_destructor(void *arg)
 
 
 static int encode_update(struct aufilt_enc_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct preproc *st;
 	unsigned sampc;
 	(void)ctx;
+	(void)au;
 
 	if (!stp || !af || !prm || prm->ch != 1)
 		return EINVAL;

--- a/modules/vumeter/vumeter.c
+++ b/modules/vumeter/vumeter.c
@@ -105,7 +105,8 @@ static void dec_tmr_handler(void *arg)
 
 
 static int encode_update(struct aufilt_enc_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct vumeter_enc *st;
 	(void)ctx;
@@ -130,7 +131,8 @@ static int encode_update(struct aufilt_enc_st **stp, void **ctx,
 
 
 static int decode_update(struct aufilt_dec_st **stp, void **ctx,
-			 const struct aufilt *af, struct aufilt_prm *prm)
+			 const struct aufilt *af, struct aufilt_prm *prm,
+			 const struct audio *au)
 {
 	struct vumeter_dec *st;
 	(void)ctx;

--- a/src/audio.c
+++ b/src/audio.c
@@ -1343,7 +1343,7 @@ static int aufilt_setup(struct audio *a)
 		void *ctx = NULL;
 
 		if (af->encupdh) {
-			err |= af->encupdh(&encst, &ctx, af, &encprm);
+			err |= af->encupdh(&encst, &ctx, af, &encprm, a);
 			if (err)
 				break;
 
@@ -1352,7 +1352,7 @@ static int aufilt_setup(struct audio *a)
 		}
 
 		if (af->decupdh) {
-			err |= af->decupdh(&decst, &ctx, af, &decprm);
+			err |= af->decupdh(&decst, &ctx, af, &decprm, a);
 			if (err)
 				break;
 


### PR DESCRIPTION
This is needed so that the audio-filter (aufilt) modules can
get access to the audio session state, and also the call object.

This commit breaks the AUFILT api.