### PR TITLE
SDL2 Win32 only workarounds:

### DIFF
--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -86,7 +86,9 @@ static void event_handler(void *arg)
 	struct vidisp_st *st = arg;
 	SDL_Event event;
 
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
+#endif
 
 	/* NOTE: events must be checked from main thread */
 	while (SDL_PollEvent(&event)) {
@@ -149,9 +151,9 @@ static int alloc(struct vidisp_st **stp, const struct vidisp *vd,
 
 	st->vd = vd;
 	st->fullscreen = prm ? prm->fullscreen : false;
-
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
-
+#endif
 	if (err)
 		mem_deref(st);
 	else
@@ -169,6 +171,10 @@ static int display(struct vidisp_st *st, const char *title,
 	int dpitch, ret;
 	unsigned i, h;
 	uint32_t format;
+
+#ifdef WIN32
+	event_handler(st);
+#endif
 
 	if (!st || !frame)
 		return EINVAL;
@@ -329,7 +335,11 @@ static int module_close(void)
 {
 	vid = mem_deref(vid);
 
+#ifdef WIN32
+	SDL_Quit();
+#else
 	SDL_VideoQuit();
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This is a proposal to fix SDL2 "unusability" on Win32:
- SDL2 window is not responsive: can't be moved, can't be  (un)changed  (from)to full screen.
- If a SDL2 display function is called (e.g. with /vidoop) then baresip crashes when exiting the application (q pressed)

Proposed fix:
- Move recursive call of event_handler from module_init (alloc function) to display function (without recursivity)
- Replace SDL_VideoQuit by SDL_Quit: this fixes applications crashes when quiting the application (video displayed with sdl2)

Testing environment:
- Cross compilation from Ubuntu 16.04.1 ( i686-w64-mingw32 toolchain, following https://github.com/alfredh/baresip-win32 )
- Binaries tested on Win10, HP laptop (core I5) 
- Webcams: integrated laptop webcam, HP HD 4310 and logitech C920
