### PR TITLE
Add a specific tagging and processing for long commands passed throug httpd

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -771,6 +771,7 @@ int  cmd_init(struct commands **commandsp);
 int  cmd_register(struct commands *commands,
 		  const struct cmd *cmdv, size_t cmdc);
 void cmd_unregister(struct commands *commands, const struct cmd *cmdv);
+int  cmd_fill_ctx(struct cmd_ctx **ctxp, char key);
 int  cmd_process(struct commands *commands, struct cmd_ctx **ctxp, char key,
 		 struct re_printf *pf, void *data);
 int  cmd_process_long(struct commands *commands, const char *str, size_t len,

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -103,6 +103,9 @@ static void http_req_handler(struct http_conn *conn,
 
 	if (0 == pl_strcasecmp(&msg->path, "/")) {
 
+	if( nprm.p[1] == '/'){ // this applies on long commands only
+		buf[1] = '@';
+	}
 		http_creply(conn, 200, "OK",
 			    "text/html;charset=UTF-8",
 			    "%H", html_print_cmd, &nprm);

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -103,7 +103,7 @@ static void http_req_handler(struct http_conn *conn,
 
 	if (0 == pl_strcasecmp(&msg->path, "/")) {
 
-	if( nprm.p[1] == '/'){ // this applies on long commands only
+	if ( nprm.p[1] == '/') { /* this applies on long commands only */
 		buf[1] = '@';
 	}
 		http_creply(conn, 200, "OK",

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -574,8 +574,8 @@ int cmd_process(struct commands *commands, struct cmd_ctx **ctxp, char key,
 
 		return cmd->h(pf, &arg);
 	}
-	else if (key == LONG_PREFIX || key == '@') { /* '@' => long httpd 
-							       command */
+	/* key == '@' <=> long httpd command */
+	else if (key == LONG_PREFIX || key == '@') {
 
 		int err;
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -357,6 +357,12 @@ int cmd_process_long(struct commands *commands, const char *str, size_t len,
 	return err;
 }
 
+int cmd_fill_ctx(struct cmd_ctx **ctxp, char key){
+	struct cmd_ctx *ctx;
+	ctx = *ctxp;
+
+	return mbuf_write_u8(ctx->mb, key);
+}
 
 static int cmd_process_edit(struct commands *commands,
 			    struct cmd_ctx **ctxp, char key,
@@ -568,11 +574,17 @@ int cmd_process(struct commands *commands, struct cmd_ctx **ctxp, char key,
 
 		return cmd->h(pf, &arg);
 	}
-	else if (key == LONG_PREFIX) {
+	else if (key == LONG_PREFIX || key == '@') { // '@' => long httpd command
 
 		int err;
 
-		err = re_hprintf(pf, "%c", LONG_PREFIX);
+		if(key == '@'){
+			err = 0;
+		}
+		else{
+			err = re_hprintf(pf, "%c", LONG_PREFIX);
+		}
+
 		if (err)
 			return err;
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -574,14 +574,15 @@ int cmd_process(struct commands *commands, struct cmd_ctx **ctxp, char key,
 
 		return cmd->h(pf, &arg);
 	}
-	else if (key == LONG_PREFIX || key == '@') { // '@' => long httpd command
+	else if (key == LONG_PREFIX || key == '@') { /* '@' => long httpd 
+							       command */
 
 		int err;
 
-		if(key == '@'){
+		if (key == '@') {
 			err = 0;
 		}
-		else{
+		else {
 			err = re_hprintf(pf, "%c", LONG_PREFIX);
 		}
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -100,7 +100,17 @@ int ui_input_pl(struct re_printf *pf, const struct pl *pl)
 		return EINVAL;
 
 	for (i=0; i<pl->l; i++) {
-		err |= cmd_process(commands, &ctx, pl->p[i], pf, NULL);
+		if(pl->p[0] == '@'){ // httpd user interface + long command
+			if( i == 0){
+				err |= cmd_process(commands, &ctx, '@', pf, NULL);
+			}
+			else{
+				cmd_fill_ctx(&ctx, pl->p[i]);
+			}
+		}
+		else{
+			err |= cmd_process(commands, &ctx, pl->p[i], pf, NULL);
+		}
 	}
 
 	if (pl->l > 1 && ctx)

--- a/src/ui.c
+++ b/src/ui.c
@@ -100,16 +100,19 @@ int ui_input_pl(struct re_printf *pf, const struct pl *pl)
 		return EINVAL;
 
 	for (i=0; i<pl->l; i++) {
-		if(pl->p[0] == '@'){ // httpd user interface + long command
-			if( i == 0){
-				err |= cmd_process(commands, &ctx, '@', pf, NULL);
+		if (pl->p[0] == '@') { /* httpd user interface 
+					  + long command */
+			if (i == 0) {
+				err |= cmd_process(commands, &ctx, '@', pf,
+						   NULL);
 			}
-			else{
+			else {
 				cmd_fill_ctx(&ctx, pl->p[i]);
 			}
 		}
 		else{
-			err |= cmd_process(commands, &ctx, pl->p[i], pf, NULL);
+			err |= cmd_process(commands, &ctx, pl->p[i], pf,
+					   NULL);
 		}
 	}
 

--- a/src/ui.c
+++ b/src/ui.c
@@ -100,11 +100,11 @@ int ui_input_pl(struct re_printf *pf, const struct pl *pl)
 		return EINVAL;
 
 	for (i=0; i<pl->l; i++) {
-		if (pl->p[0] == '@') { /* httpd user interface 
-					  + long command */
+		/* httpd user interface + long command */
+		if (pl->p[0] == '@') {
 			if (i == 0) {
 				err |= cmd_process(commands, &ctx, '@', pf,
-						   NULL);
+							NULL);
 			}
 			else {
 				cmd_fill_ctx(&ctx, pl->p[i]);


### PR DESCRIPTION
This is a proposal to avoid the 'cascading' effect of long command name printing with httpd  UI.
    
Example with /vidloop command (http://127.0.0.1:8000/?/vidloop):

"Cascading" effect

	/
	/v
	/vi
	/vid
	/vidl
	/vidlo
	/vidloo
	/vidloop
	Enable video-loop on ,: 352 x 288

With the proposed patch

	Enable video-loop on ,: 352 x 288

Tested on Ubuntu 16.04 (Firefox) and Win10 (Firefox, Chrome)


