### PR TITLE
don't append domain if uri is IP address.

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -8,6 +8,7 @@
 #include <baresip.h>
 #include "core.h"
 #include <ctype.h>
+#include <arpa/inet.h>
 
 
 /** Magic number */
@@ -739,6 +740,8 @@ static int uri_complete(struct ua *ua, struct mbuf *buf, const char *uri)
 {
 	size_t len;
 	int err = 0;
+	int uri_is_ip = 0;
+	struct sockaddr_in sa;
 
 	/* Skip initial whitespace */
 	while (isspace(*uri))
@@ -752,8 +755,12 @@ static int uri_complete(struct ua *ua, struct mbuf *buf, const char *uri)
 
 	err |= mbuf_write_str(buf, uri);
 
-	/* Append domain if missing */
-	if (0 != re_regex(uri, len, "[^@]+@[^]+", NULL, NULL)) {
+	/* Append domain if missing and uri is not IP address */
+    uri_is_ip = inet_pton(AF_INET, uri, &(sa.sin_addr));	// check if uri is valid IPv4 address
+#if HAVE_INET6
+	uri_is_ip |= inet_pton(AF_INET6, uri, &(sa.sin_addr));  // check if uri is valid IPv6 address
+#endif
+    if (0 != re_regex(uri, len, "[^@]+@[^]+", NULL, NULL) && 1 != uri_is_ip) {
 #if HAVE_INET6
 		if (AF_INET6 == ua->acc->luri.af)
 			err |= mbuf_printf(buf, "@[%r]",

--- a/src/ua.c
+++ b/src/ua.c
@@ -756,9 +756,9 @@ static int uri_complete(struct ua *ua, struct mbuf *buf, const char *uri)
 	err |= mbuf_write_str(buf, uri);
 
 	/* Append domain if missing and uri is not IP address */
-    uri_is_ip = inet_pton(AF_INET, uri, &(sa.sin_addr));	// check if uri is valid IPv4 address
+    uri_is_ip = inet_pton(AF_INET, uri, &(sa.sin_addr));	/* check if uri is valid IPv4 address */
 #if HAVE_INET6
-	uri_is_ip |= inet_pton(AF_INET6, uri, &(sa.sin_addr));  // check if uri is valid IPv6 address
+	uri_is_ip |= inet_pton(AF_INET6, uri, &(sa.sin_addr));  /* check if uri is valid IPv6 address */
 #endif
     if (0 != re_regex(uri, len, "[^@]+@[^]+", NULL, NULL) && 1 != uri_is_ip) {
 #if HAVE_INET6


### PR DESCRIPTION
If user use IP address of peer, uri_complete try to append domain to the uri and call doesn't established. In this pull request first we check peer uri and if it is IP address we don't append domain to it.