### PR TITLE
Sdl2 threads

### DIFF
--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -86,7 +86,9 @@ static void event_handler(void *arg)
 	struct vidisp_st *st = arg;
 	SDL_Event event;
 
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
+#endif
 
 	/* NOTE: events must be checked from main thread */
 	while (SDL_PollEvent(&event)) {
@@ -149,9 +151,9 @@ static int alloc(struct vidisp_st **stp, const struct vidisp *vd,
 
 	st->vd = vd;
 	st->fullscreen = prm ? prm->fullscreen : false;
-
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
-
+#endif
 	if (err)
 		mem_deref(st);
 	else
@@ -169,6 +171,10 @@ static int display(struct vidisp_st *st, const char *title,
 	int dpitch, ret;
 	unsigned i, h;
 	uint32_t format;
+
+#ifdef WIN32
+	event_handler(st);
+#endif
 
 	if (!st || !frame)
 		return EINVAL;
@@ -329,7 +335,11 @@ static int module_close(void)
 {
 	vid = mem_deref(vid);
 
+#ifdef WIN32
+	SDL_Quit();
+#else
 	SDL_VideoQuit();
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
This is a new proposal to address https://github.com/alfredh/baresip/pull/451 code reviews and last comment analyses related to performances issues.

All SDL2 functions are called from the main thread:
-  video frames are pushed through the new push_frame registered function
- a pushed frame is stored in an intermediary vidframe structure before being displayed
- once the video frame is copied, a timer is set to render the frame thanks to new display_handler function.

Tested with vidloops and calls on Win10 and Ubuntu 16.04
