### PR TITLE
Vidloop threads

### DIFF
--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -86,7 +86,9 @@ static void event_handler(void *arg)
 	struct vidisp_st *st = arg;
 	SDL_Event event;
 
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
+#endif
 
 	/* NOTE: events must be checked from main thread */
 	while (SDL_PollEvent(&event)) {
@@ -149,9 +151,9 @@ static int alloc(struct vidisp_st **stp, const struct vidisp *vd,
 
 	st->vd = vd;
 	st->fullscreen = prm ? prm->fullscreen : false;
-
+#ifndef WIN32
 	tmr_start(&st->tmr, 100, event_handler, st);
-
+#endif
 	if (err)
 		mem_deref(st);
 	else
@@ -169,6 +171,10 @@ static int display(struct vidisp_st *st, const char *title,
 	int dpitch, ret;
 	unsigned i, h;
 	uint32_t format;
+
+#ifdef WIN32
+	event_handler(st);
+#endif
 
 	if (!st || !frame)
 		return EINVAL;
@@ -329,7 +335,11 @@ static int module_close(void)
 {
 	vid = mem_deref(vid);
 
+#ifdef WIN32
+	SDL_Quit();
+#else
 	SDL_VideoQuit();
+#endif
 
 	return 0;
 }

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -248,7 +248,7 @@ static int packet_handler(bool marker, uint64_t rtp_ts,
 		vl->frame = &frame;
 		pthread_mutex_unlock(&vl->frame_mutex);
 		/* NOTE: usually (e.g. SDL2),
-				 video frame must be rendered from main thread */
+			 video frame must be rendered from main thread */
 		tmr_start(&vl->tmr_display, 0, display_handler, vl);
 	}
 


### PR DESCRIPTION
This is a proposal to address  https://github.com/alfredh/baresip/pull/451 last comment analyses.
As suggested, video frames are rendered/displayed from main thread and the logic is moved to vidloop module.

Tested with SDL2 display, on win10 and ubuntu 16.04