### PR TITLE
Vidloop fix: video frame rendering is moved to main thread

### DIFF
--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -140,7 +140,6 @@ static void display_handler(void *arg)
 	if (err == ENODEV) {
 		info("vidloop: video-display was closed\n");
 		vl->vidisp = mem_deref(vl->vidisp);
-		vl->err = err;
 	}
 
 	pthread_mutex_unlock(&vl->frame_mutex);


### PR DESCRIPTION
This is a proposal to address #451 last comment analyses.
As suggested, video frames are rendered/displayed from main thread and the logic is moved to vidloop module.
A mutex is used to protect vl->frame and vl->disp accesses
A frame copy is needed in order to provide the display module with final pixel values.

Tested with SDL2 display, on win10 and ubuntu 16.04