### PR TITLE
audio: remove audio_srate and audio_channels

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -16,8 +16,6 @@ sip_trans_bsize		128
 audio_player		alsa,default
 audio_source		alsa,default
 audio_alert		alsa,default
-audio_srate		8000-48000
-audio_channels		1-2
 #ausrc_srate		48000
 #auplay_srate		48000
 #ausrc_channels		0

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -230,8 +230,6 @@ struct config_audio {
 	char play_dev[128];     /**< Audio playback device          */
 	char alert_mod[16];     /**< Audio alert module             */
 	char alert_dev[128];    /**< Audio alert device             */
-	struct range srate;     /**< Audio sampling rate in [Hz]    */
-	struct range channels;  /**< Nr. of audio channels (1=mono) */
 	uint32_t srate_play;    /**< Opt. sampling rate for player  */
 	uint32_t srate_src;     /**< Opt. sampling rate for source  */
 	uint32_t channels_play; /**< Opt. channels for player       */

--- a/src/audio.c
+++ b/src/audio.c
@@ -357,18 +357,6 @@ static bool aucodec_equal(const struct aucodec *a, const struct aucodec *b)
 static int add_audio_codec(struct audio *a, struct sdp_media *m,
 			   struct aucodec *ac)
 {
-	if (!in_range(&a->cfg.srate, get_srate(ac))) {
-		debug("audio: skip %uHz codec (audio range %uHz - %uHz)\n",
-		      get_srate(ac), a->cfg.srate.min, a->cfg.srate.max);
-		return 0;
-	}
-
-	if (!in_range(&a->cfg.channels, get_ch(ac))) {
-		debug("audio: skip codec with %uch (audio range %uch-%uch)\n",
-		      get_ch(ac), a->cfg.channels.min, a->cfg.channels.max);
-		return 0;
-	}
-
 	if (ac->crate < 8000) {
 		warning("audio: illegal clock rate %u\n", ac->crate);
 		return EINVAL;

--- a/src/config.c
+++ b/src/config.c
@@ -47,8 +47,6 @@ static struct config core_config = {
 		"","",
 		"","",
 		"","",
-		{8000, 48000},
-		{1, 2},
 		0,
 		0,
 		0,
@@ -277,8 +275,6 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   cfg->audio.alert_dev,
 			   sizeof(cfg->audio.alert_dev));
 
-	(void)conf_get_range(conf, "audio_srate", &cfg->audio.srate);
-	(void)conf_get_range(conf, "audio_channels", &cfg->audio.channels);
 	(void)conf_get_u32(conf, "ausrc_srate", &cfg->audio.srate_src);
 	(void)conf_get_u32(conf, "auplay_srate", &cfg->audio.srate_play);
 	(void)conf_get_u32(conf, "ausrc_channels", &cfg->audio.channels_src);
@@ -396,8 +392,6 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "audio_player\t\t%s,%s\n"
 			 "audio_source\t\t%s,%s\n"
 			 "audio_alert\t\t%s,%s\n"
-			 "audio_srate\t\t%H\n"
-			 "audio_channels\t\t%H\n"
 			 "auplay_srate\t\t%u\n"
 			 "ausrc_srate\t\t%u\n"
 			 "auplay_channels\t\t%u\n"
@@ -444,8 +438,6 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->audio.play_mod,  cfg->audio.play_dev,
 			 cfg->audio.src_mod,   cfg->audio.src_dev,
 			 cfg->audio.alert_mod, cfg->audio.alert_dev,
-			 range_print, &cfg->audio.srate,
-			 range_print, &cfg->audio.channels,
 			 cfg->audio.srate_play, cfg->audio.srate_src,
 			 cfg->audio.channels_play, cfg->audio.channels_src,
 			 cfg->audio.level ? "yes" : "no",
@@ -578,8 +570,6 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "audio_player\t\t%s\n"
 			  "audio_source\t\t%s\n"
 			  "audio_alert\t\t%s\n"
-			  "audio_srate\t\t%u-%u\n"
-			  "audio_channels\t\t%u-%u\n"
 			  "#ausrc_srate\t\t48000\n"
 			  "#auplay_srate\t\t48000\n"
 			  "#ausrc_channels\t\t0\n"
@@ -596,10 +586,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  cfg->call.max_calls,
 			  default_audio_device(),
 			  default_audio_device(),
-			  default_audio_device(),
-			  cfg->audio.srate.min, cfg->audio.srate.max,
-			  cfg->audio.channels.min, cfg->audio.channels.max
-			  );
+			  default_audio_device());
 
 #ifdef USE_VIDEO
 	err |= re_hprintf(pf,


### PR DESCRIPTION
remove these config options:

  audio_srate            8000-48000
  audio_channels         1-2

these options has no practical usage, except to limit the
enabled audio codecs to the range of samplerate/channels
as specified.

if a module has multiple audio codecs, and you only want
to use one of them, this can now be done with the
"audio_codecs" parameter to the "accounts" file.