### PR TITLE
aucodec: add packet channels (pch) to struct

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -938,6 +938,7 @@ struct aucodec {
 	uint32_t srate;             /* Audio samplerate */
 	uint32_t crate;             /* RTP Clock rate   */
 	uint8_t ch;
+	uint8_t pch;                /* RTP packet channels */
 	const char *fmtp;
 	auenc_update_h *encupdh;
 	auenc_encode_h *ench;

--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -306,7 +306,7 @@ static int decode_nb(struct audec_state *st, int fmt, void *sampv,
 
 #ifdef AMR_WB
 static struct aucodec amr_wb = {
-	LE_INIT, NULL, "AMR-WB", 16000, 16000, 1, NULL,
+	LE_INIT, NULL, "AMR-WB", 16000, 16000, 1, 1, NULL,
 	encode_update, encode_wb,
 	decode_update, decode_wb,
 	NULL, amr_fmtp_enc, amr_fmtp_cmp
@@ -314,7 +314,7 @@ static struct aucodec amr_wb = {
 #endif
 #ifdef AMR_NB
 static struct aucodec amr_nb = {
-	LE_INIT, NULL, "AMR", 8000, 8000, 1, NULL,
+	LE_INIT, NULL, "AMR", 8000, 8000, 1, 1, NULL,
 	encode_update, encode_nb,
 	decode_update, decode_nb,
 	NULL, amr_fmtp_enc, amr_fmtp_cmp

--- a/modules/bv32/bv32.c
+++ b/modules/bv32/bv32.c
@@ -163,7 +163,7 @@ static int plc(struct audec_state *st, int fmt, void *sampv, size_t *sampc)
 
 
 static struct aucodec bv32 = {
-	LE_INIT, 0, "BV32", 16000, 16000, 1, NULL,
+	LE_INIT, 0, "BV32", 16000, 16000, 1, 1, NULL,
 	encode_update, encode,
 	decode_update, decode, plc,
 	NULL, NULL

--- a/modules/codec2/codec2.c
+++ b/modules/codec2/codec2.c
@@ -173,6 +173,7 @@ static struct aucodec codec2 = {
 	8000,
 	8000,
 	1,
+	1,
 	NULL,
 	encode_update,
 	encode,

--- a/modules/g711/g711.c
+++ b/modules/g711/g711.c
@@ -117,12 +117,12 @@ static int pcma_decode(struct audec_state *ads, int fmt, void *sampv,
 
 
 static struct aucodec pcmu = {
-	LE_INIT, "0", "PCMU", 8000, 8000, 1, NULL,
+	LE_INIT, "0", "PCMU", 8000, 8000, 1, 1, NULL,
 	NULL, pcmu_encode, NULL, pcmu_decode, NULL, NULL, NULL
 };
 
 static struct aucodec pcma = {
-	LE_INIT, "8", "PCMA", 8000, 8000, 1, NULL,
+	LE_INIT, "8", "PCMA", 8000, 8000, 1, 1, NULL,
 	NULL, pcma_encode, NULL, pcma_decode, NULL, NULL, NULL
 };
 

--- a/modules/g722/g722.c
+++ b/modules/g722/g722.c
@@ -169,7 +169,7 @@ static int decode(struct audec_state *st, int fmt, void *sampv, size_t *sampc,
 
 
 static struct aucodec g722 = {
-	LE_INIT, "9", "G722", 16000, 8000, 1, NULL,
+	LE_INIT, "9", "G722", 16000, 8000, 1, 1, NULL,
 	encode_update, encode,
 	decode_update, decode, NULL,
 	NULL, NULL

--- a/modules/g7221/g7221.c
+++ b/modules/g7221/g7221.c
@@ -15,6 +15,7 @@ static struct g7221_aucodec g7221 = {
 		.srate     = 16000,
 		.crate     = 16000,
 		.ch        = 1,
+		.pch       = 1,
 		.encupdh   = g7221_encode_update,
 		.ench      = g7221_encode,
 		.decupdh   = g7221_decode_update,

--- a/modules/g726/g726.c
+++ b/modules/g726/g726.c
@@ -155,28 +155,28 @@ static int decode(struct audec_state *st, int fmt, void *sampv,
 static struct g726_aucodec g726[4] = {
 	{
 		{
-			LE_INIT, 0, "G726-40", 8000, 8000, 1, NULL,
+			LE_INIT, 0, "G726-40", 8000, 8000, 1, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		40000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-32", 8000, 8000, 1, NULL,
+			LE_INIT, 0, "G726-32", 8000, 8000, 1, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		32000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-24", 8000, 8000, 1, NULL,
+			LE_INIT, 0, "G726-24", 8000, 8000, 1, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		24000
 	},
 	{
 		{
-			LE_INIT, 0, "G726-16", 8000, 8000, 1, NULL,
+			LE_INIT, 0, "G726-16", 8000, 8000, 1, 1, NULL,
 			encode_update, encode, decode_update, decode, 0, 0, 0
 		},
 		16000

--- a/modules/gsm/gsm.c
+++ b/modules/gsm/gsm.c
@@ -156,7 +156,7 @@ static int decode(struct audec_state *st, int fmt, void *sampv, size_t *sampc,
 
 
 static struct aucodec ac_gsm = {
-	LE_INIT, "3", "GSM", 8000, 8000, 1, NULL,
+	LE_INIT, "3", "GSM", 8000, 8000, 1, 1, NULL,
 	encode_update, encode, decode_update, decode, NULL, NULL, NULL
 };
 

--- a/modules/ilbc/ilbc.c
+++ b/modules/ilbc/ilbc.c
@@ -327,7 +327,7 @@ static int pkloss(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 
 static struct aucodec ilbc = {
-	LE_INIT, 0, "iLBC", 8000, 8000, 1, ilbc_fmtp,
+	LE_INIT, 0, "iLBC", 8000, 8000, 1, 1, ilbc_fmtp,
 	encode_update, encode, decode_update, decode, pkloss, 0, 0
 };
 

--- a/modules/isac/isac.c
+++ b/modules/isac/isac.c
@@ -186,11 +186,11 @@ static int plc(struct audec_state *st, int16_t *sampv, size_t *sampc)
 
 static struct aucodec isacv[] = {
 	{
-	LE_INIT, 0, "isac", 32000, 32000, 1, NULL,
+	LE_INIT, 0, "isac", 32000, 32000, 1, 1, NULL,
 	encode_update, encode, decode_update, decode, plc, NULL, NULL
 	},
 	{
-	LE_INIT, 0, "isac", 16000, 16000, 1, NULL,
+	LE_INIT, 0, "isac", 16000, 16000, 1, 1, NULL,
 	encode_update, encode, decode_update, decode, plc, NULL, NULL
 	}
 };

--- a/modules/l16/l16.c
+++ b/modules/l16/l16.c
@@ -71,14 +71,14 @@ static int decode(struct audec_state *st, int fmt, void *sampv, size_t *sampc,
 
 /* See RFC 3551 */
 static struct aucodec l16v[NR_CODECS] = {
-{LE_INIT, "10", "L16", 44100, 44100, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 32000, 32000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 16000, 16000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16",  8000,  8000, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT, "11", "L16", 44100, 44100, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 32000, 32000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 16000, 16000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16",  8000,  8000, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT, "10", "L16", 44100, 44100, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 32000, 32000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 16000, 16000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16",  8000,  8000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT, "11", "L16", 44100, 44100, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 32000, 32000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 16000, 16000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16",  8000,  8000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
 };
 
 

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -83,7 +83,8 @@ static struct aucodec mpa = {
 	.name      = "MPA",
 	.srate     = MPA_IORATE,
 	.crate     = MPA_RTPRATE,
-	.ch       = 1,
+	.ch        = 2,
+	.pch       = 1,
 /* MPA does not expect channels count, even those it is stereo */
 	.fmtp      = "layer=2",
 	.encupdh   = mpa_encode_update,

--- a/modules/opus/opus.c
+++ b/modules/opus/opus.c
@@ -63,6 +63,7 @@ static struct aucodec opus = {
 	.srate     = 48000,
 	.crate     = 48000,
 	.ch        = 2,
+	.pch       = 2,
 	.fmtp      = fmtp,
 	.encupdh   = opus_encode_update,
 	.ench      = opus_encode_frm,

--- a/modules/silk/silk.c
+++ b/modules/silk/silk.c
@@ -235,7 +235,7 @@ static int plc(struct audec_state *st, int fmt, void *sampv, size_t *sampc)
 
 static struct aucodec silk[] = {
 	{
-		LE_INIT, 0, "SILK", 24000, 24000, 1, NULL,
+		LE_INIT, 0, "SILK", 24000, 24000, 1, 1, NULL,
 		encode_update, encode, decode_update, decode, plc, 0, 0
 	},
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -374,8 +374,14 @@ static int add_audio_codec(struct audio *a, struct sdp_media *m,
 		return EINVAL;
 	}
 
+	if (ac->ch == 0 || ac->pch == 0) {
+		warning("audio: illegal channels for audio codec '%s'\n",
+			ac->name);
+		return EINVAL;
+	}
+
 	return sdp_format_add(NULL, m, false, ac->pt, ac->name, ac->crate,
-			      ac->ch, ac->fmtp_ench, ac->fmtp_cmph, ac, false,
+			      ac->pch, ac->fmtp_ench, ac->fmtp_cmph, ac, false,
 			      "%s", ac->fmtp);
 }
 

--- a/test/mock/mock_aucodec.c
+++ b/test/mock/mock_aucodec.c
@@ -84,7 +84,8 @@ static struct aucodec ac_dummy = {
 	.name = "FOO16",
 	.srate = 8000,
 	.crate = 8000,
-	.ch = 1,
+	.ch  = 1,
+	.pch = 1,
 	.ench = mock_l16_encode,
 	.dech = mock_l16_decode,
 };


### PR DESCRIPTION
this is currently only needed for the MPA codec, where the
audio channel count and RTP-packet channel count differs.