### PR TITLE
check to make sure the device is running before dereferencing it.

### DIFF
--- a/modules/aubridge/device.c
+++ b/modules/aubridge/device.c
@@ -59,6 +59,10 @@ static void *device_thread(void *arg)
 	size_t sampc_out;
 	int err;
 
+	if (!dev->run) {
+		goto out;
+	}
+	
 	sampc_in = dev->auplay->prm.srate * dev->auplay->prm.ch * PTIME/1000;
 	sampc_out = dev->ausrc->prm.srate * dev->ausrc->prm.ch * PTIME/1000;
 


### PR DESCRIPTION
I realize that the echo module is experimental, however I noticed the occasional core file when using it and this solution appears to fix it.
