### PR TITLE
consider empty contacts file as existing contacts file

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -63,7 +63,7 @@ bool conf_fileexist(const char *path)
 	if ((st.st_mode & S_IFMT) != S_IFREG)
 		 return false;
 
-	return st.st_size > 0;
+	return true;
 }
 
 


### PR DESCRIPTION
Accept also empty contacts file as existing contacts file.  When baresip is started with empty contacts file,
it now does not create a new default one, but reports:

Populated 0 contacts
