### PR TITLE
Prevent buffering standard I/O

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,11 @@ int main(int argc, char *argv[])
 	size_t i;
 	int err;
 
+	/*
+	 * turn off buffering on stdout
+	 */
+	setbuf(stdout, NULL);
+
 	(void)re_fprintf(stdout, "baresip v%s"
 			 " Copyright (C) 2010 - 2018"
 			 " Alfred E. Heggestad et al.\n",


### PR DESCRIPTION
- do not buffer output/input to any of stdin, stdout, stderr
  - without this change, the new UI infrastructure buffers all output
until the application is killed; makes it impossible to control
programatically