### PR TITLE
RTCP summary module

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1127,7 +1127,13 @@ double video_timestamp_to_seconds(uint64_t timestamp);
 
 const struct rtcp_stats *stream_rtcp_stats(const struct stream *strm);
 struct call *stream_call(const struct stream *strm);
-
+const struct sdp_media *stream_sdp(const struct stream *strm);
+uint32_t metric_get_tx_n_packets(const struct stream *strm);
+uint32_t metric_get_tx_n_bytes(const struct stream *strm);
+uint32_t metric_get_tx_n_err(const struct stream *strm);
+uint32_t metric_get_rx_n_packets(const struct stream *strm);
+uint32_t metric_get_rx_n_bytes(const struct stream *strm);
+uint32_t metric_get_rx_n_err(const struct stream *strm);
 
 /*
  * Media NAT

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1128,12 +1128,12 @@ double video_timestamp_to_seconds(uint64_t timestamp);
 const struct rtcp_stats *stream_rtcp_stats(const struct stream *strm);
 struct call *stream_call(const struct stream *strm);
 const struct sdp_media *stream_sdp(const struct stream *strm);
-uint32_t metric_get_tx_n_packets(const struct stream *strm);
-uint32_t metric_get_tx_n_bytes(const struct stream *strm);
-uint32_t metric_get_tx_n_err(const struct stream *strm);
-uint32_t metric_get_rx_n_packets(const struct stream *strm);
-uint32_t metric_get_rx_n_bytes(const struct stream *strm);
-uint32_t metric_get_rx_n_err(const struct stream *strm);
+uint32_t stream_metric_get_tx_n_packets(const struct stream *strm);
+uint32_t stream_metric_get_tx_n_bytes(const struct stream *strm);
+uint32_t stream_metric_get_tx_n_err(const struct stream *strm);
+uint32_t stream_metric_get_rx_n_packets(const struct stream *strm);
+uint32_t stream_metric_get_rx_n_bytes(const struct stream *strm);
+uint32_t stream_metric_get_rx_n_err(const struct stream *strm);
 
 /*
  * Media NAT

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -53,7 +53,6 @@
 #   USE_V4L2          Video4Linux2 module
 #   USE_WINWAVE       Windows audio driver
 #   USE_X11           X11 video output
-#   USE_ECHO          echo module
 #   USE_RTCPSUMMARY   RTCP summary output after calls
 #
 
@@ -462,9 +461,6 @@ MODULES   += gzrtp
 endif
 ifneq ($(USE_DSHOW),)
 MODULES   += dshow
-endif
-ifneq ($(USE_ECHO),)
-MODULES   += echo
 endif
 ifneq ($(USE_RTCPSUMMARY),)
 MODULES   += rtcpsummary

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -53,6 +53,8 @@
 #   USE_V4L2          Video4Linux2 module
 #   USE_WINWAVE       Windows audio driver
 #   USE_X11           X11 video output
+#   USE_ECHO          echo module
+#   USE_RTCPSUMMARY   RTCP summary output after calls
 #
 
 
@@ -460,4 +462,10 @@ MODULES   += gzrtp
 endif
 ifneq ($(USE_DSHOW),)
 MODULES   += dshow
+endif
+ifneq ($(USE_ECHO),)
+MODULES   += echo
+endif
+ifneq ($(USE_RTCPSUMMARY),)
+MODULES   += rtcpsummary
 endif

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -41,6 +41,7 @@
 #   USE_PLC           Packet Loss Concealment
 #   USE_PORTAUDIO     Portaudio audio driver
 #   USE_PULSE         Pulseaudio audio driver
+#   USE_RTCPSUMMARY   RTCP summary output after calls
 #   USE_SDL           libSDL video output
 #   USE_SILK          SILK (Skype) audio codec
 #   USE_SNDFILE       sndfile wav dumper
@@ -53,7 +54,6 @@
 #   USE_V4L2          Video4Linux2 module
 #   USE_WINWAVE       Windows audio driver
 #   USE_X11           X11 video output
-#   USE_RTCPSUMMARY   RTCP summary output after calls
 #
 
 

--- a/modules/rtcpsummary/module.mk
+++ b/modules/rtcpsummary/module.mk
@@ -1,0 +1,11 @@
+#
+# module.mk
+#
+# Copyright (C) 2010 Creytiv.com
+#
+
+MOD		:= rtcpsummary
+$(MOD)_SRCS	+= rtcpsummary.c
+$(MOD)_LFLAGS	+=
+
+include mk/mod.mk

--- a/modules/rtcpsummary/rtcpsummary.c
+++ b/modules/rtcpsummary/rtcpsummary.c
@@ -1,0 +1,96 @@
+/**
+ * @file rtcpsummary.c RTCP summary module
+ * Output RTCP stats at the end of a call if there are any
+ */
+#include <re.h>
+#include <baresip.h>
+
+static void ua_event_handler(struct ua *ua,
+			     enum ua_event ev,
+			     struct call *call,
+			     const char *prm,
+			     void *arg ) {
+	(void)call;
+	struct le *le;
+	const struct rtcp_stats *rtcp;
+	const struct stream *s;
+
+	switch (ev) {
+
+		case UA_EVENT_CALL_CLOSED:
+			debug("rtcpsummary: CALL_CLOSED");
+				for (le = call_streaml(call)->head; le; le = le->next) {
+					s = le->data;
+					rtcp = stream_rtcp_stats(s);
+
+					if (rtcp && (rtcp->tx.sent || rtcp->rx.sent)) {
+
+						info("\n");
+						/*
+						 * Add a stats line to make it easier to parse result from script/
+						 * Use a similar format use for the X-RTP-STAT header in a SIP bye message
+						 * See audio.c
+						 */
+						info("EX=BareSip;"   /* Reporter Identifier	             */
+							 "CS=%d;"        /* Call Setup in milliseconds       */
+							 "CD=%d;"        /* Call Duration in seconds	     */
+							 "PR=%u;PS=%u;"  /* Packets RX, TX according to RTCP */
+							 "PL=%d,%d;"     /* Packets Lost RX, TX              */
+							 "PD=%d,%d;"     /* Packets Discarded, RX, TX        */
+							 "JI=%.1f,%.1f;" /* Jitter RX, TX in ms 		     */
+							 "DL=%.1f;"      /* RTT in ms					     */
+							 "IP=%J,%J;"     /* Local, Remote IPs                */
+							 "\n"
+							,
+							 call_setup_duration(stream_call(s)) * 1000,
+							 call_duration(stream_call(s)),
+							 rtcp->rx.sent,
+							 rtcp->tx.sent,
+							 rtcp->rx.lost,
+							 rtcp->tx.lost,
+							 metric_get_rx_n_err(s),
+							 metric_get_tx_n_err(s),
+							 1.0 * rtcp->rx.jit/1000,
+							 1.0 * rtcp->tx.jit/1000,
+							 1.0 * rtcp->rtt/1000,
+							 sdp_media_laddr(stream_sdp(s)),
+							 sdp_media_raddr(stream_sdp(s)));
+					} else {
+						// put a line showing how RTCP stats were NOT collected
+						info("\n");
+						info("EX=BareSip;ERROR=No RTCP stats collected;\n");
+					}
+				}
+			break;
+
+		default:
+			break;
+	}
+}
+
+
+static int module_init(void)
+{
+	int err = uag_event_register(ua_event_handler, NULL);
+	if (err) {
+		info("Error loading rtcpsummary module: %d", err);
+		return err;
+	}
+	return 0;
+}
+
+
+static int module_close(void)
+{
+	debug("rtcpsummary: module closing..\n");
+	uag_event_unregister(ua_event_handler);
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(rtcpsummary) = {
+	"rtcpsummary",
+	"application",
+	module_init,
+	module_close
+};

--- a/modules/rtcpsummary/rtcpsummary.c
+++ b/modules/rtcpsummary/rtcpsummary.c
@@ -19,48 +19,74 @@ static void ua_event_handler(struct ua *ua,
 
 		case UA_EVENT_CALL_CLOSED:
 			debug("rtcpsummary: CALL_CLOSED");
-				for (le = call_streaml(call)->head; le; le = le->next) {
-					s = le->data;
-					rtcp = stream_rtcp_stats(s);
+			for (	le = call_streaml(call)->head;
+						le;
+						le = le->next) {
+				s = le->data;
+				rtcp = stream_rtcp_stats(s);
 
-					if (rtcp && (rtcp->tx.sent || rtcp->rx.sent)) {
+				if (rtcp && (rtcp->tx.sent || rtcp->rx.sent)) {
 
-						info("\n");
-						/*
-						 * Add a stats line to make it easier to parse result from script/
-						 * Use a similar format use for the X-RTP-STAT header in a SIP bye message
-						 * See audio.c
-						 */
-						info("EX=BareSip;"   /* Reporter Identifier	             */
-							 "CS=%d;"        /* Call Setup in milliseconds       */
-							 "CD=%d;"        /* Call Duration in seconds	     */
-							 "PR=%u;PS=%u;"  /* Packets RX, TX according to RTCP */
-							 "PL=%d,%d;"     /* Packets Lost RX, TX              */
-							 "PD=%d,%d;"     /* Packets Discarded, RX, TX        */
-							 "JI=%.1f,%.1f;" /* Jitter RX, TX in ms 		     */
-							 "DL=%.1f;"      /* RTT in ms					     */
-							 "IP=%J,%J;"     /* Local, Remote IPs                */
-							 "\n"
-							,
-							 call_setup_duration(stream_call(s)) * 1000,
-							 call_duration(stream_call(s)),
-							 rtcp->rx.sent,
-							 rtcp->tx.sent,
-							 rtcp->rx.lost,
-							 rtcp->tx.lost,
-							 metric_get_rx_n_err(s),
-							 metric_get_tx_n_err(s),
-							 1.0 * rtcp->rx.jit/1000,
-							 1.0 * rtcp->tx.jit/1000,
-							 1.0 * rtcp->rtt/1000,
-							 sdp_media_laddr(stream_sdp(s)),
-							 sdp_media_raddr(stream_sdp(s)));
-					} else {
-						// put a line showing how RTCP stats were NOT collected
-						info("\n");
-						info("EX=BareSip;ERROR=No RTCP stats collected;\n");
-					}
+					info("\n");
+					/*
+					 * Add a stats line to make it
+					 * easier to parse result
+					 * from script. Use a similar
+					 * format use for the
+					 * X-RTP-STAT header in a SIP
+					 * bye message.
+					 * See audio.c
+					 */
+					info("EX=BareSip;"
+						 /* Reporter Identifier */
+						 "CS=%d;"
+						 /* Call Setup in ms */
+						 "CD=%d;"
+						 /* Call Duration in sec */
+						 "PR=%u;PS=%u;"
+						 /* Packets RX, TX via RTCP */
+						 "PL=%d,%d;"
+						 /* Packets Lost RX, TX */
+						 "PD=%d,%d;"
+						 /* Packets Discarded, RX,TX */
+						 "JI=%.1f,%.1f;"
+						 /* Jitter RX, TX in ms */
+						 "DL=%.1f;"
+						 /* RTT in ms */
+						 "IP=%J,%J;"
+						 /* Local, Remote IPs */
+						 "\n"
+						,
+						 call_setup_duration(
+							 stream_call(s))
+							 * 1000,
+						 call_duration(
+							 stream_call(s)),
+						 rtcp->rx.sent,
+						 rtcp->tx.sent,
+						 rtcp->rx.lost,
+						 rtcp->tx.lost,
+						 metric_get_rx_n_err(s),
+						 metric_get_tx_n_err(s),
+						 1.0 * rtcp->rx.jit/1000,
+						 1.0 * rtcp->tx.jit/1000,
+						 1.0 * rtcp->rtt/1000,
+						 sdp_media_laddr(
+							 stream_sdp(s)),
+						 sdp_media_raddr(
+							 stream_sdp(s)));
 				}
+				else {
+					/*
+					  * put a line showing how
+						* RTCP stats were NOT collected
+						*/
+					info("\n");
+					info("EX=BareSip;"
+						"ERROR=No RTCP "
+						"stats collected;\n");
+				}
+			}
 			break;
 
 		default:

--- a/src/main.c
+++ b/src/main.c
@@ -79,13 +79,6 @@ int main(int argc, char *argv[])
 	size_t i;
 	int err;
 
-	/*
-	 * turn off buffering to stdout, stderr, stdin
-	 */
-	setbuf(stdout, NULL);
-	setbuf(stderr, NULL);
-	setbuf(stdin, NULL);
-
 	(void)re_fprintf(stdout, "baresip v%s"
 			 " Copyright (C) 2010 - 2018"
 			 " Alfred E. Heggestad et al.\n",

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,13 @@ int main(int argc, char *argv[])
 	size_t i;
 	int err;
 
+	/*
+	 * turn off buffering to stdout, stderr, stdin
+	 */
+	setbuf(stdout, NULL);
+	setbuf(stderr, NULL);
+	setbuf(stdin, NULL);
+
 	(void)re_fprintf(stdout, "baresip v%s"
 			 " Copyright (C) 2010 - 2018"
 			 " Alfred E. Heggestad et al.\n",

--- a/src/stream.c
+++ b/src/stream.c
@@ -756,3 +756,34 @@ struct call *stream_call(const struct stream *strm)
 {
 	return strm ? strm->call : NULL;
 }
+
+/**
+ * Get the sdp object from the stream
+ *
+ * @param strm Stream object
+ *
+ * @return SDP media object
+ */
+const struct sdp_media *stream_sdp(const struct stream *strm)
+{
+	return strm ? strm->sdp : NULL;
+}
+
+uint32_t metric_get_tx_n_packets(const struct stream *strm) {
+	return strm ? strm->metric_tx.n_packets : 0;
+}
+uint32_t metric_get_tx_n_bytes(const struct stream *strm) {
+	return strm ? strm->metric_tx.n_bytes : 0;
+}
+uint32_t metric_get_tx_n_err(const struct stream *strm) {
+	return strm ? strm->metric_tx.n_err : 0;
+}
+uint32_t metric_get_rx_n_packets(const struct stream *strm) {
+	return strm ? strm->metric_rx.n_packets : 0;
+}
+uint32_t metric_get_rx_n_bytes(const struct stream *strm) {
+	return strm ? strm->metric_rx.n_bytes : 0;
+}
+uint32_t metric_get_rx_n_err(const struct stream *strm) {
+	return strm ? strm->metric_rx.n_err : 0;
+}

--- a/src/stream.c
+++ b/src/stream.c
@@ -769,21 +769,27 @@ const struct sdp_media *stream_sdp(const struct stream *strm)
 	return strm ? strm->sdp : NULL;
 }
 
-uint32_t metric_get_tx_n_packets(const struct stream *strm) {
+uint32_t stream_metric_get_tx_n_packets(const struct stream *strm)
+{
 	return strm ? strm->metric_tx.n_packets : 0;
 }
-uint32_t metric_get_tx_n_bytes(const struct stream *strm) {
+uint32_t stream_metric_get_tx_n_bytes(const struct stream *strm)
+{
 	return strm ? strm->metric_tx.n_bytes : 0;
 }
-uint32_t metric_get_tx_n_err(const struct stream *strm) {
+uint32_t stream_metric_get_tx_n_err(const struct stream *strm)
+{
 	return strm ? strm->metric_tx.n_err : 0;
 }
-uint32_t metric_get_rx_n_packets(const struct stream *strm) {
+uint32_t stream_metric_get_rx_n_packets(const struct stream *strm)
+{
 	return strm ? strm->metric_rx.n_packets : 0;
 }
-uint32_t metric_get_rx_n_bytes(const struct stream *strm) {
+uint32_t stream_metric_get_rx_n_bytes(const struct stream *strm)
+{
 	return strm ? strm->metric_rx.n_bytes : 0;
 }
-uint32_t metric_get_rx_n_err(const struct stream *strm) {
+uint32_t stream_metric_get_rx_n_err(const struct stream *strm)
+{
 	return strm ? strm->metric_rx.n_err : 0;
 }


### PR DESCRIPTION
 - new module: rtcpsummary
   - At the end of a call, output the RTCP stats in a format that's easily parsed
   - expose some read-only info from stream.c