### PR TITLE
x11: remove old path

### DIFF
--- a/modules/x11/module.mk
+++ b/modules/x11/module.mk
@@ -6,7 +6,7 @@
 
 MOD		:= x11
 $(MOD)_SRCS	+= x11.c
-$(MOD)_LFLAGS	+= -L$(SYSROOT)/X11/lib -lX11 -lXext
+$(MOD)_LFLAGS	+= -lX11 -lXext
 $(MOD)_CFLAGS	+= -Wno-variadic-macros
 
 include mk/mod.mk


### PR DESCRIPTION
the current code gives a warning on OSX:

```
  CC [M]  build-x86_64/modules/x11/x11.o
  LD [M]  x11.so
ld: warning: directory not found for option '-L/usr/X11/lib'
```
