### PR TITLE
call: Support also SIP URI with missing display name.

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -742,7 +742,7 @@ int call_connect(struct call *call, const struct pl *paddr)
 	/* if the peer-address is a full SIP address then we need
 	 * to parse it and extract the SIP uri part.
 	 */
-	if (0 == sip_addr_decode(&addr, paddr) && addr.dname.p) {
+	if (0 == sip_addr_decode(&addr, paddr)) {
 		err = pl_strdup(&call->peer_uri, &addr.auri);
 	}
 	else {


### PR DESCRIPTION
In function call_connect SIP URIs like "<sip:user@host>" are not supported. The
log tells us:

 call: sipsess_connect: Function not implemented

This is because the angle brackets are present and the display name is missing.
The patch achieves that the empty display name is ignored and the URI is
accepted.