### PR TITLE
alsa: On termination of alsa_play wait until buffer was processed.

### DIFF
--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -86,6 +86,8 @@ static void *write_thread(void *arg)
 		}
 	}
 
+	snd_pcm_drain(st->write);
+
 	return NULL;
 }
 


### PR DESCRIPTION
When the write_thread finishes we have to wait until ALSA has processed it's
internal buffer before we call snd_pcm_close. This can be achieved by calling
snd_pcm_drain.