### PR TITLE
Vidfilt add timestamp

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1073,12 +1073,12 @@ struct vidfilt_dec_st {
 typedef int (vidfilt_encupd_h)(struct vidfilt_enc_st **stp, void **ctx,
 			       const struct vidfilt *vf);
 typedef int (vidfilt_encode_h)(struct vidfilt_enc_st *st,
-			       struct vidframe *frame);
+			       struct vidframe *frame, uint64_t *timestamp);
 
 typedef int (vidfilt_decupd_h)(struct vidfilt_dec_st **stp, void **ctx,
 			       const struct vidfilt *vf);
 typedef int (vidfilt_decode_h)(struct vidfilt_dec_st *st,
-			       struct vidframe *frame);
+			       struct vidframe *frame, uint64_t *timestamp);
 
 struct vidfilt {
 	struct le le;

--- a/modules/selfview/selfview.c
+++ b/modules/selfview/selfview.c
@@ -152,7 +152,8 @@ static int decode_update(struct vidfilt_dec_st **stp, void **ctx,
 }
 
 
-static int encode_win(struct vidfilt_enc_st *st, struct vidframe *frame)
+static int encode_win(struct vidfilt_enc_st *st, struct vidframe *frame,
+		      uint64_t *timestamp)
 {
 	struct selfview_enc *enc = (struct selfview_enc *)st;
 	int err;
@@ -172,7 +173,8 @@ static int encode_win(struct vidfilt_enc_st *st, struct vidframe *frame)
 }
 
 
-static int encode_pip(struct vidfilt_enc_st *st, struct vidframe *frame)
+static int encode_pip(struct vidfilt_enc_st *st, struct vidframe *frame,
+		      uint64_t *timestamp)
 {
 	struct selfview_enc *enc = (struct selfview_enc *)st;
 	struct selfview *selfview = enc->selfview;
@@ -204,7 +206,8 @@ static int encode_pip(struct vidfilt_enc_st *st, struct vidframe *frame)
 }
 
 
-static int decode_pip(struct vidfilt_dec_st *st, struct vidframe *frame)
+static int decode_pip(struct vidfilt_dec_st *st, struct vidframe *frame,
+		      uint64_t *timestamp)
 {
 	struct selfview_dec *dec = (struct selfview_dec *)st;
 	struct selfview *sv = dec->selfview;

--- a/modules/selfview/selfview.c
+++ b/modules/selfview/selfview.c
@@ -157,6 +157,7 @@ static int encode_win(struct vidfilt_enc_st *st, struct vidframe *frame,
 {
 	struct selfview_enc *enc = (struct selfview_enc *)st;
 	int err;
+	(void)timestamp;
 
 	if (!frame)
 		return 0;
@@ -179,6 +180,7 @@ static int encode_pip(struct vidfilt_enc_st *st, struct vidframe *frame,
 	struct selfview_enc *enc = (struct selfview_enc *)st;
 	struct selfview *selfview = enc->selfview;
 	int err = 0;
+	(void)timestamp;
 
 	if (!frame)
 		return 0;
@@ -211,6 +213,7 @@ static int decode_pip(struct vidfilt_dec_st *st, struct vidframe *frame,
 {
 	struct selfview_dec *dec = (struct selfview_dec *)st;
 	struct selfview *sv = dec->selfview;
+	(void)timestamp;
 
 	if (!frame)
 		return 0;

--- a/modules/snapshot/snapshot.c
+++ b/modules/snapshot/snapshot.c
@@ -27,9 +27,11 @@
 static bool flag_enc, flag_dec;
 
 
-static int encode(struct vidfilt_enc_st *st, struct vidframe *frame)
+static int encode(struct vidfilt_enc_st *st, struct vidframe *frame,
+		  uint64_t *timestamp)
 {
 	(void)st;
+	(void)timestamp;
 
 	if (!frame)
 		return 0;
@@ -43,9 +45,11 @@ static int encode(struct vidfilt_enc_st *st, struct vidframe *frame)
 }
 
 
-static int decode(struct vidfilt_dec_st *st, struct vidframe *frame)
+static int decode(struct vidfilt_dec_st *st, struct vidframe *frame,
+		  uint64_t *timestamp)
 {
 	(void)st;
+	(void)timestamp;
 
 	if (!frame)
 		return 0;

--- a/modules/swscale/swscale.c
+++ b/modules/swscale/swscale.c
@@ -79,7 +79,8 @@ static int encode_update(struct vidfilt_enc_st **stp, void **ctx,
 }
 
 
-static int encode_process(struct vidfilt_enc_st *st, struct vidframe *frame)
+static int encode_process(struct vidfilt_enc_st *st, struct vidframe *frame,
+			  uint64_t *timestamp)
 {
 	struct swscale_enc *enc = (struct swscale_enc *)st;
 	enum AVPixelFormat avpixfmt, avpixfmt_dst;
@@ -88,6 +89,7 @@ static int encode_process(struct vidfilt_enc_st *st, struct vidframe *frame)
 	int srcStride[4], dstStride[4];
 	int width, height, i, h;
 	int err = 0;
+	(void)timestamp;
 
 	if (!st)
 		return EINVAL;

--- a/modules/vidinfo/vidinfo.c
+++ b/modules/vidinfo/vidinfo.c
@@ -101,7 +101,8 @@ static int decode_update(struct vidfilt_dec_st **stp, void **ctx,
 }
 
 
-static int encode(struct vidfilt_enc_st *_st, struct vidframe *frame)
+static int encode(struct vidfilt_enc_st *_st, struct vidframe *frame,
+		  uint64_t *timestamp)
 {
 	struct vidinfo_enc *st = (struct vidinfo_enc *)_st;
 	int err = 0;
@@ -124,7 +125,8 @@ static int encode(struct vidfilt_enc_st *_st, struct vidframe *frame)
 }
 
 
-static int decode(struct vidfilt_dec_st *_st, struct vidframe *frame)
+static int decode(struct vidfilt_dec_st *_st, struct vidframe *frame,
+		  uint64_t *timestamp)
 {
 	struct vidinfo_dec *st = (struct vidinfo_dec *)_st;
 	int err = 0;

--- a/src/video.c
+++ b/src/video.c
@@ -430,7 +430,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 		struct vidfilt_enc_st *st = le->data;
 
 		if (st->vf && st->vf->ench)
-			err |= st->vf->ench(st, frame);
+			err |= st->vf->ench(st, frame, &timestamp);
 	}
 
 	if (err)
@@ -691,7 +691,7 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 		struct vidfilt_dec_st *st = le->data;
 
 		if (st->vf && st->vf->dech)
-			err |= st->vf->dech(st, frame);
+			err |= st->vf->dech(st, frame, &timestamp);
 	}
 
 	++vrx->stats.disp_frames;


### PR DESCRIPTION
add timestamp parameter to the Vidfilt API.

this allows a video filter module to read and to modify the frame timestamp.

updated modules:

* selfview
* snapshot
* swscale
* vidinfo


