### PR TITLE
Use extra CA file for TLS transport

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -11,6 +11,7 @@ poll_method		epoll		# poll, select, epoll ..
 sip_trans_bsize		128
 #sip_listen		0.0.0.0:5060
 #sip_certificate	cert.pem
+#sip_ca			ca.crt
 
 # Audio
 audio_player		alsa,default

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -220,6 +220,7 @@ struct config_sip {
 	char uuid[64];          /**< Universally Unique Identifier  */
 	char local[64];         /**< Local SIP Address              */
 	char cert[256];         /**< SIP Certificate                */
+	char ca[256];           /**< SIP CA                         */
 };
 
 /** Call config */

--- a/src/config.c
+++ b/src/config.c
@@ -249,6 +249,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   sizeof(cfg->sip.local));
 	(void)conf_get_str(conf, "sip_certificate", cfg->sip.cert,
 			   sizeof(cfg->sip.cert));
+	(void)conf_get_str(conf, "sip_ca", cfg->sip.ca,
+			   sizeof(cfg->sip.ca));
 
 	/* Call */
 	(void)conf_get_u32(conf, "call_local_timeout",

--- a/src/ua.c
+++ b/src/ua.c
@@ -1177,6 +1177,18 @@ static int add_transp_af(const struct sa *laddr)
 				warning("ua: tls_alloc() failed: %m\n", err);
 				return err;
 			}
+
+			if (str_isset(uag.cfg->ca)) {
+				const char *ca = NULL;
+				ca = uag.cfg->ca;
+				info("SIP CA: %s\n", ca);
+
+				err = tls_add_ca(uag.tls, ca);
+				if (err) {
+					warning("ua: tls_add_ca() failed: %m\n", err);
+					return err;
+				}
+			}
 		}
 
 		if (sa_isset(&local, SA_PORT))

--- a/src/ua.c
+++ b/src/ua.c
@@ -1185,7 +1185,8 @@ static int add_transp_af(const struct sa *laddr)
 
 				err = tls_add_ca(uag.tls, ca);
 				if (err) {
-					warning("ua: tls_add_ca() failed: %m\n", err);
+					warning("ua: tls_add_ca() failed:"
+						" %m\n", err);
 					return err;
 				}
 			}


### PR DESCRIPTION
Added a new option to baresip configuration called sip_ca that is used the set an extra CA file for TLS transport.

In combination with pull request [tls: set verify methode for openSSL 1.1.0 #155](https://github.com/creytiv/re/pull/155) from creytiv/re
a TLS connection to a server can use the CA file checking if the pem file is created with
this CA and is still valid.