### PR TITLE
dshow: mediadev support

### DIFF
--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -188,7 +188,7 @@ static int enum_devices(struct vidsrc_st *st, const char *name,
 	ULONG fetched;
 	HRESULT res;
 	int id = 0;
-	int err = 0 ;
+	int err = 0;
 
 	res = CoCreateInstance(CLSID_SystemDeviceEnum, NULL,
 			       CLSCTX_INPROC_SERVER,


### PR DESCRIPTION
Hi,
This PR is an  implementation of set_available_devices in dshow module.

Testing environment:
- Cross compilation from Ubuntu 16.04.1 ( i686-w64-mingw32 toolchain, following https://github.com/alfredh/baresip-win32 )
- Binaries tested on Win10