### PR TITLE
dshow: fix missing parenthesis in enum_devices

### DIFF
--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -180,7 +180,7 @@ static struct vidsrc *vsrc;
 
 
 static int enum_devices(struct vidsrc_st *st, const char *name,
-			struct list *dev_list
+			struct list *dev_list)
 {
 	ICreateDevEnum *dev_enum;
 	IEnumMoniker *enum_mon;


### PR DESCRIPTION
Fix compilation error reported in https://github.com/alfredh/baresip/pull/550

Testing environment:
- Cross compilation from Ubuntu 16.04.1 ( i686-w64-mingw32 toolchain, following https://github.com/alfredh/baresip-win32 )
- Binaries tested on Win10
