### PR TITLE
winwave: mediadev support

### DIFF
--- a/modules/winwave/winwave.c
+++ b/modules/winwave/winwave.c
@@ -54,7 +54,7 @@ int enum_devices(const char *name, struct list *dev_list,
 		}
 
 		if (dev) {
-			if(!str_casecmp(name, dev_name)) {
+			if (!str_casecmp(name, dev_name)) {
 				*dev = i;
 				break;
 			}

--- a/modules/winwave/winwave.c
+++ b/modules/winwave/winwave.c
@@ -23,6 +23,54 @@ static struct ausrc *ausrc;
 static struct auplay *auplay;
 
 
+int enum_devices(const char *name, struct list *dev_list,
+		 unsigned int *dev,
+		 unsigned int (winwave_get_num_devs)(void),
+		 int (winwave_get_dev_name)(unsigned int, char*))
+{
+	/* The szPname member of the WAVEINCAPS/WAVEOUTCAPS structures
+	   is limited to MAXPNAMELEN characters, which is defined as 32 */
+	char dev_name[32];
+	int err = 0;
+	unsigned int i, nDevices = winwave_get_num_devs();
+
+
+	if (!dev_list && !dev)
+		return EINVAL;
+
+	if (dev) {
+		*dev = WAVE_MAPPER;
+
+		if (!str_isset(name)) {
+			return 0;
+		}
+	}
+
+	for (i=0; i<nDevices; i++) {
+
+		err = winwave_get_dev_name (i, dev_name);
+		if (err) {
+			break;
+		}
+
+		if (dev) {
+			if(!str_casecmp(name, dev_name)) {
+				*dev = i;
+				break;
+			}
+		}
+		else {
+			err = mediadev_add(dev_list, dev_name);
+			if (err) {
+				break;
+			}
+		}
+	}
+
+	return err;
+}
+
+
 static int ww_init(void)
 {
 	int play_dev_count, src_dev_count;
@@ -38,6 +86,12 @@ static int ww_init(void)
 			      "winwave", winwave_src_alloc);
 	err |= auplay_register(&auplay, baresip_auplayl(),
 			       "winwave", winwave_play_alloc);
+
+	if (err)
+		return err;
+
+	err  = winwave_player_init(auplay);
+	err |= winwave_src_init(ausrc);
 
 	return err;
 }

--- a/modules/winwave/winwave.h
+++ b/modules/winwave/winwave.h
@@ -18,3 +18,9 @@ int winwave_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 int winwave_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 		       struct auplay_prm *prm, const char *device,
 		       auplay_write_h *wh, void *arg);
+int enum_devices(const char *name, struct list *dev_list,
+		 unsigned int *dev,
+		 unsigned int (winwave_get_num_devs)(void),
+		 int (winwave_get_dev_name)(unsigned int, char[32]));
+int winwave_src_init(struct ausrc *as);
+int winwave_player_init(struct auplay *ap);


### PR DESCRIPTION
This PR is an  implementation of set_available_devices in winwave module.

Testing environment:
- Cross compilation from Ubuntu 16.04.1 ( i686-w64-mingw32 toolchain, following https://github.com/alfredh/baresip-win32 )
- Binaries tested on Win10
