### PR TITLE
mediadev: check if device already exists in mediadev_add

### DIFF
--- a/src/mediadev.c
+++ b/src/mediadev.c
@@ -23,6 +23,10 @@ int mediadev_add(struct list *dev_list, const char *name)
 	if (!dev_list || !str_isset(name))
 		return EINVAL;
 
+	if (mediadev_find(dev_list, name)) {
+		return 0;
+	}
+
 	dev = mem_zalloc(sizeof(*dev), destructor);
 	if (!dev)
 		return ENOMEM;


### PR DESCRIPTION
In response to duplicated devices observed from linux/wine testing environment and reported here https://github.com/alfredh/baresip/pull/550#issuecomment-427644290

Tested with dshow, pulse and v4l2 modules.