### PR TITLE
winwave: add support for FLOAT sample format

### DIFF
--- a/modules/winwave/winwave.c
+++ b/modules/winwave/winwave.c
@@ -7,6 +7,7 @@
 #include <rem.h>
 #include <windows.h>
 #include <mmsystem.h>
+#include <mmreg.h>
 #include <baresip.h>
 #include "winwave.h"
 
@@ -68,6 +69,17 @@ int winwave_enum_devices(const char *name, struct list *dev_list,
 	}
 
 	return err;
+}
+
+
+unsigned winwave_get_format(enum aufmt fmt)
+{
+	switch (fmt) {
+
+	case AUFMT_S16LE:   return WAVE_FORMAT_PCM;
+	case AUFMT_FLOAT:   return WAVE_FORMAT_IEEE_FLOAT;
+	default:            return WAVE_FORMAT_UNKNOWN;
+	}
 }
 
 

--- a/modules/winwave/winwave.h
+++ b/modules/winwave/winwave.h
@@ -24,3 +24,4 @@ int winwave_enum_devices(const char *name, struct list *dev_list,
 			 int (winwave_get_dev_name)(unsigned int, char[32]));
 int winwave_src_init(struct ausrc *as);
 int winwave_player_init(struct auplay *ap);
+unsigned winwave_get_format(enum aufmt fmt);


### PR DESCRIPTION
This PR adds support for FLOAT sample format.

See here for a list of audio drivers and sample formats:

https://github.com/alfredh/baresip/wiki/Audio-sample-formats
