### PR TITLE
avcapture: fix video resolutions mismatches

### DIFF
--- a/modules/avcapture/avcapture.m
+++ b/modules/avcapture/avcapture.m
@@ -103,9 +103,10 @@ static void vidframe_set_pixbuf(struct vidframe *f, const CVImageBufferRef b)
 		struct vidsz sz;
 		NSString * const * preset;
 	} mapv[] = {
-		{{ 192, 144}, &AVCaptureSessionPresetLow     },
-		{{ 480, 360}, &AVCaptureSessionPresetMedium  },
-		{{ 640, 480}, &AVCaptureSessionPresetHigh    },
+		{{ 320 ,240}, &AVCaptureSessionPreset320x240 },
+		{{ 352, 288}, &AVCaptureSessionPreset352x288 },
+		{{ 640, 480}, &AVCaptureSessionPreset640x480 },
+		{{ 960, 540}, &AVCaptureSessionPreset960x540 },
 		{{1280, 720}, &AVCaptureSessionPreset1280x720}
 	};
 	int i, best = -1;
@@ -118,9 +119,8 @@ static void vidframe_set_pixbuf(struct vidframe *f, const CVImageBufferRef b)
 		    ![dev supportsAVCaptureSessionPreset:preset])
 			continue;
 
-		if (mapv[i].sz.w >= sz->w && mapv[i].sz.h >= sz->h)
-			best = i;
-		else
+		best = i;
+		if (mapv[i].sz.w <= sz->w && mapv[i].sz.h <= sz->h)
 			break;
 	}
 
@@ -128,7 +128,7 @@ static void vidframe_set_pixbuf(struct vidframe *f, const CVImageBufferRef b)
 		return *mapv[best].preset;
 	else {
 		NSLog(@"no suitable preset found for %d x %d", sz->w, sz->h);
-		return AVCaptureSessionPresetHigh;
+		return AVCaptureSessionPreset352x288;
 	}
 }
 


### PR DESCRIPTION
This PR is a proposal to fix video resolutions mismatches in avcapture (map_preset function).

AVCaptureSessionPresetLow, AVCaptureSessionPresetMedium and AVCaptureSessionPresetHigh seem to be device dependent. 
For instance, if I configure video_size  640x480, I get AVCaptureSessionPresetHigh which is mapped to 1280x720 with my macbook => video resolutions written explicitly in this patch.

With the current implementation, we can get a resolution upper than the configured video_size. 
For instance, if I configure video_size  854x480, I get AVCaptureSessionPreset1280x720.
My understanding is that the required video resolution should be considered as an upper bound => in the patch map_preset returns the upper resolution for which frame width and heigh are lower than the required values.

To be consistent with default video_size value, AVCaptureSessionPreset352x288 should be returned when "no suitable preset found".

Testing environnement: MacBook Pro, OSX (10.13.6) + compiled with clang

