### PR TITLE
make 'audio' and 'stream' independent of 'call'

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1131,10 +1131,14 @@ int audio_alloc(struct audio **ap, const struct stream_param *stream_prm,
 	struct autx *tx;
 	struct aurx *rx;
 	struct le *le;
+	char cname[12];
 	int err;
 
 	if (!ap || !cfg)
 		return EINVAL;
+
+	if (!call)
+		rand_str(cname, sizeof(cname));
 
 	a = mem_zalloc(sizeof(*a), audio_destructor);
 	if (!a)
@@ -1155,7 +1159,7 @@ int audio_alloc(struct audio **ap, const struct stream_param *stream_prm,
 	err = stream_alloc(&a->strm, stream_prm, &cfg->avt, call, sdp_sess,
 			   "audio", label,
 			   mnat, mnat_sess, menc, menc_sess,
-			   call_localuri(call),
+			   call ? call_localuri(call) : cname,
 			   stream_recv_handler, NULL, a);
 	if (err)
 		goto out;

--- a/src/stream.c
+++ b/src/stream.c
@@ -365,7 +365,7 @@ int stream_alloc(struct stream **sp, const struct stream_param *prm,
 	struct stream *s;
 	int err;
 
-	if (!sp || !prm || !cfg || !call || !rtph)
+	if (!sp || !prm || !cfg || !rtph)
 		return EINVAL;
 
 	s = mem_zalloc(sizeof(*s), stream_destructor);
@@ -383,7 +383,7 @@ int stream_alloc(struct stream **sp, const struct stream_param *prm,
 	s->rtcp  = s->cfg.rtcp_enable;
 
 	if (prm->use_rtp) {
-		err = stream_sock_alloc(s, call_af(call));
+		err = stream_sock_alloc(s, call ? call_af(call) : AF_INET);
 		if (err) {
 			warning("stream: failed to create socket"
 				" for media '%s' (%m)\n", name, err);

--- a/src/video.c
+++ b/src/video.c
@@ -855,10 +855,14 @@ int video_alloc(struct video **vp, const struct stream_param *stream_prm,
 {
 	struct video *v;
 	struct le *le;
+	char cname[12];
 	int err = 0;
 
 	if (!vp || !cfg)
 		return EINVAL;
+
+	if (!call)
+		rand_str(cname, sizeof(cname));
 
 	v = mem_zalloc(sizeof(*v), video_destructor);
 	if (!v)
@@ -872,7 +876,7 @@ int video_alloc(struct video **vp, const struct stream_param *stream_prm,
 	err = stream_alloc(&v->strm, stream_prm,
 			   &cfg->avt, call, sdp_sess, "video", label,
 			   mnat, mnat_sess, menc, menc_sess,
-			   call_localuri(call),
+			   call ? call_localuri(call) : cname,
 			   stream_recv_handler, rtcp_handler, v);
 	if (err)
 		goto out;


### PR DESCRIPTION
With these few changes baresip `audio` and `stream` do not depend on `call`