### PR TITLE
sdl2: make window resizable

### DIFF
--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -195,7 +195,8 @@ static int display(struct vidisp_st *st, const char *title,
 	if (!st->window) {
 		char capt[256];
 
-		st->flags = SDL_WINDOW_SHOWN | SDL_WINDOW_INPUT_FOCUS;
+		st->flags  = SDL_WINDOW_SHOWN | SDL_WINDOW_INPUT_FOCUS;
+		st->flags |= SDL_WINDOW_RESIZABLE ;
 
 		if (st->fullscreen)
 			st->flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;

--- a/modules/sdl2/sdl.c
+++ b/modules/sdl2/sdl.c
@@ -196,7 +196,7 @@ static int display(struct vidisp_st *st, const char *title,
 		char capt[256];
 
 		st->flags  = SDL_WINDOW_SHOWN | SDL_WINDOW_INPUT_FOCUS;
-		st->flags |= SDL_WINDOW_RESIZABLE ;
+		st->flags |= SDL_WINDOW_RESIZABLE;
 
 		if (st->fullscreen)
 			st->flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;


### PR DESCRIPTION
Not a lot, but It would be nice to have resizable window with SDL2.

Tested with win 10, Ubuntu 16.04 and OSX 10.13.6