### PR TITLE
coreaudio: mediadev support

### DIFF
--- a/modules/coreaudio/coreaudio.c
+++ b/modules/coreaudio/coreaudio.c
@@ -81,7 +81,7 @@ void audio_session_disable(void)
 #endif
 
 
-int coreaudio_enum_devices (const char *name, struct list *dev_list,
+int coreaudio_enum_devices(const char *name, struct list *dev_list,
 			    CFStringRef *uid, Boolean is_input)
 {
 	AudioObjectPropertyAddress propertyAddress = {
@@ -103,9 +103,8 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 	if (uid) {
 		*uid = NULL;
 
-		if (!str_isset(name)) {
+		if (!str_isset(name))
 			return 0;
-		}
 	}
 
 	status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
@@ -143,12 +142,10 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 		goto out;
 	}
 
-	if (is_input) {
+	if (is_input)
 		propertyAddress.mScope = kAudioDevicePropertyScopeInput;
-	}
-	else {
+	else
 		propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
-	}
 
 	for (UInt32 i = 0; i < deviceCount; ++i) {
 
@@ -162,9 +159,8 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 							0,
 							NULL,
 							&dataSize);
-		if (dataSize == 0) {
+		if (dataSize == 0)
 			continue;
-		}
 
 		dataSize = sizeof(deviceUID);
 		propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;

--- a/modules/coreaudio/coreaudio.c
+++ b/modules/coreaudio/coreaudio.c
@@ -117,7 +117,7 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 		warning("AudioObjectGetPropertyDataSize"
 			" (kAudioHardwarePropertyDevices) failed: %i\n",
 			status);
-		err = 1;
+		err = ENODEV;
 		goto out;
 	}
 
@@ -139,7 +139,7 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 		warning("AudioObjectGetPropertyData"
 			" (kAudioHardwarePropertyDevices) failed: %i\n",
 			status);
-		err = 1;
+		err = ENODEV;
 		goto out;
 	}
 
@@ -209,9 +209,8 @@ int coreaudio_enum_devices (const char *name, struct list *dev_list,
 		}
 		else {
 			err = mediadev_add(dev_list, name_str);
-			if (err) {
+			if (err)
 				break;
-			}
 		}
 	}
 

--- a/modules/coreaudio/coreaudio.c
+++ b/modules/coreaudio/coreaudio.c
@@ -81,7 +81,8 @@ void audio_session_disable(void)
 #endif
 
 
-CFStringRef coreaudio_get_device_uid(const char *name)
+int coreaudio_enum_devices (const char *name, struct list *dev_list,
+			    CFStringRef *uid, Boolean is_input)
 {
 	AudioObjectPropertyAddress propertyAddress = {
 		kAudioHardwarePropertyDevices,
@@ -94,7 +95,18 @@ CFStringRef coreaudio_get_device_uid(const char *name)
 	UInt32 deviceCount;
 	OSStatus status;
 
-	CFStringRef found_deviceUID = NULL;
+	int err = 0;
+
+	if (!dev_list && !uid)
+		return EINVAL;
+
+	if (uid) {
+		*uid = NULL;
+
+		if (!str_isset(name)) {
+			return 0;
+		}
+	}
 
 	status = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
 						&propertyAddress,
@@ -105,14 +117,17 @@ CFStringRef coreaudio_get_device_uid(const char *name)
 		warning("AudioObjectGetPropertyDataSize"
 			" (kAudioHardwarePropertyDevices) failed: %i\n",
 			status);
+		err = 1;
 		goto out;
 	}
 
 	deviceCount = dataSize / sizeof(AudioDeviceID);
 
 	audioDevices = mem_zalloc(dataSize, NULL);
-	if (NULL == audioDevices)
+	if (NULL == audioDevices) {
+		err = ENOMEM;
 		goto out;
+	}
 
 	status = AudioObjectGetPropertyData(kAudioObjectSystemObject,
 					    &propertyAddress,
@@ -124,16 +139,32 @@ CFStringRef coreaudio_get_device_uid(const char *name)
 		warning("AudioObjectGetPropertyData"
 			" (kAudioHardwarePropertyDevices) failed: %i\n",
 			status);
+		err = 1;
 		goto out;
 	}
 
-	propertyAddress.mScope = kAudioDevicePropertyScopeInput;
+	if (is_input) {
+		propertyAddress.mScope = kAudioDevicePropertyScopeInput;
+	}
+	else {
+		propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
+	}
 
 	for (UInt32 i = 0; i < deviceCount; ++i) {
 
 		CFStringRef deviceUID = NULL;
 		CFStringRef deviceName = NULL;
 		const char *name_str;
+
+		propertyAddress.mSelector   = kAudioDevicePropertyStreams;
+		status = AudioObjectGetPropertyDataSize(audioDevices[i],
+							&propertyAddress,
+							0,
+							NULL,
+							&dataSize);
+		if (dataSize == 0) {
+			continue;
+		}
 
 		dataSize = sizeof(deviceUID);
 		propertyAddress.mSelector = kAudioDevicePropertyDeviceUID;
@@ -170,16 +201,24 @@ CFStringRef coreaudio_get_device_uid(const char *name)
 		name_str = CFStringGetCStringPtr(deviceName,
 						 kCFStringEncodingUTF8);
 
-		if (0 == str_casecmp(name, name_str)) {
-			found_deviceUID = deviceUID;
-			break;
+		if (uid) {
+			if (0 == str_casecmp(name, name_str)) {
+				*uid = deviceUID;
+				break;
+			}
+		}
+		else {
+			err = mediadev_add(dev_list, name_str);
+			if (err) {
+				break;
+			}
 		}
 	}
 
  out:
 	mem_deref(audioDevices);
 
-	return found_deviceUID;
+	return err;
 }
 
 
@@ -191,6 +230,12 @@ static int module_init(void)
 			       "coreaudio", coreaudio_player_alloc);
 	err |= ausrc_register(&ausrc, baresip_ausrcl(),
 			      "coreaudio", coreaudio_recorder_alloc);
+
+	if (err)
+		return err;
+
+	err  = coreaudio_player_init(auplay);
+	err |= coreaudio_recorder_init(ausrc);
 
 	return err;
 }

--- a/modules/coreaudio/coreaudio.h
+++ b/modules/coreaudio/coreaudio.h
@@ -16,6 +16,7 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 			     struct media_ctx **ctx,
 			     struct ausrc_prm *prm, const char *device,
 			     ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
-
-
-CFStringRef coreaudio_get_device_uid(const char *name);
+int coreaudio_enum_devices (const char *name, struct list *dev_list,
+			    CFStringRef *uid, Boolean is_input);
+int coreaudio_player_init(struct auplay *ap);
+int coreaudio_recorder_init(struct ausrc *as);

--- a/modules/coreaudio/coreaudio.h
+++ b/modules/coreaudio/coreaudio.h
@@ -16,7 +16,7 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 			     struct media_ctx **ctx,
 			     struct ausrc_prm *prm, const char *device,
 			     ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
-int coreaudio_enum_devices (const char *name, struct list *dev_list,
+int coreaudio_enum_devices(const char *name, struct list *dev_list,
 			    CFStringRef *uid, Boolean is_input);
 int coreaudio_player_init(struct auplay *ap);
 int coreaudio_recorder_init(struct ausrc *as);

--- a/modules/coreaudio/player.c
+++ b/modules/coreaudio/player.c
@@ -132,7 +132,10 @@ int coreaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 		info("coreaudio: player: using device '%s'\n", device);
 
-		uid = coreaudio_get_device_uid(device);
+		err = coreaudio_enum_devices(device, NULL, &uid, false);
+		if (err)
+			goto out;
+
 		if (!uid) {
 			warning("coreaudio: player: device not found: '%s'\n",
 				device);
@@ -187,4 +190,16 @@ int coreaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 		*stp = st;
 
 	return err;
+}
+
+
+int coreaudio_player_init(struct auplay *ap)
+{
+	if (!ap) {
+		return EINVAL;
+	}
+
+	list_init(&ap->dev_list);
+
+	return coreaudio_enum_devices (NULL, &ap->dev_list, NULL, false);
 }

--- a/modules/coreaudio/player.c
+++ b/modules/coreaudio/player.c
@@ -195,11 +195,10 @@ int coreaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 int coreaudio_player_init(struct auplay *ap)
 {
-	if (!ap) {
+	if (!ap)
 		return EINVAL;
-	}
 
 	list_init(&ap->dev_list);
 
-	return coreaudio_enum_devices (NULL, &ap->dev_list, NULL, false);
+	return coreaudio_enum_devices(NULL, &ap->dev_list, NULL, false);
 }

--- a/modules/coreaudio/recorder.c
+++ b/modules/coreaudio/recorder.c
@@ -207,9 +207,8 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 int coreaudio_recorder_init(struct ausrc *as)
 {
-	if (!as) {
+	if (!as)
 		return EINVAL;
-	}
 
 	list_init(&as->dev_list);
 

--- a/modules/coreaudio/recorder.c
+++ b/modules/coreaudio/recorder.c
@@ -152,7 +152,10 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 		info("coreaudio: recorder: using device '%s'\n", device);
 
-		uid = coreaudio_get_device_uid(device);
+		err = coreaudio_enum_devices(device, NULL, &uid, true);
+		if (err)
+			goto out;
+
 		if (!uid) {
 			warning("coreaudio: recorder: device not found:"
 				" '%s'\n", device);
@@ -199,4 +202,16 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		*stp = st;
 
 	return err;
+}
+
+
+int coreaudio_recorder_init(struct ausrc *as)
+{
+	if (!as) {
+		return EINVAL;
+	}
+
+	list_init(&as->dev_list);
+
+	return coreaudio_enum_devices (NULL, &as->dev_list, NULL, true);
 }


### PR DESCRIPTION
This  patch adds mediadev support in coreaudio.

Tested from OSX 10.13.6