### PR TITLE
avcodec: force intra (H.263, H.264) frame request if no key frame received

### DIFF
--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -278,6 +278,9 @@ int decode_h264(struct viddec_state *st, struct vidframe *frame,
 	if (err)
 		return err;
 
+	if (!h264_is_keyframe(h264_hdr.type) && !st->got_keyframe)
+		return EPROTO;
+
 #if 0
 	re_printf("avcodec: decode: %s %s type=%2d %s  \n",
 		  marker ? "[M]" : "   ",
@@ -480,6 +483,9 @@ int decode_h263(struct viddec_state *st, struct vidframe *frame,
 	err = h263_hdr_decode(&hdr, src);
 	if (err)
 		return err;
+
+	if (hdr.i && !st->got_keyframe)
+		return EPROTO;
 
 #if 0
 	debug(".....[%s seq=%5u ] MODE %s -"


### PR DESCRIPTION
This patch adds a check in decode_h263 and decode_h264 in order to return an error while the decoding process has not been initiated with a key frame (~intra frame).
This error is returned in video_stream_decode (video.c), triggering a RTCP FIR.

This aims at avoiding infinite loop with no key frame received/processed (=> no decoded video)