### PR TITLE
audiounit: add AUConverter resampler (recorder)

### DIFF
--- a/modules/audiounit/audiounit.h
+++ b/modules/audiounit/audiounit.h
@@ -11,12 +11,22 @@ AudioComponent audiounit_comp_conv;
 
 struct audiosess;
 struct audiosess_st;
+struct conv_buf;
+
 
 typedef void (audiosess_int_h)(bool start, void *arg);
 
 int  audiosess_alloc(struct audiosess_st **stp,
 		     audiosess_int_h *inth, void *arg);
 void audiosess_interrupt(bool interrupted);
+
+
+int conv_buf_alloc(struct conv_buf **bufp, size_t framesz);
+int  get_nb_frames(struct conv_buf *buf, uint32_t *nb_frames);
+OSStatus init_data_write(struct conv_buf *buf, void **data,
+			 size_t framesz, uint32_t nb_frames);
+OSStatus init_data_read(struct conv_buf *buf, void **data,
+			size_t framesz, uint32_t nb_frames);
 
 
 int audiounit_player_alloc(struct auplay_st **stp, const struct auplay *ap,

--- a/modules/audiounit/audiounit.h
+++ b/modules/audiounit/audiounit.h
@@ -5,7 +5,8 @@
  */
 
 
-AudioComponent audiounit_comp;
+AudioComponent audiounit_comp_io;
+AudioComponent audiounit_comp_conv;
 
 
 struct audiosess;

--- a/modules/audiounit/player.c
+++ b/modules/audiounit/player.c
@@ -129,7 +129,7 @@ int audiounit_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (err)
 		goto out;
 
-	ret = AudioComponentInstanceNew(audiounit_comp, &st->au);
+	ret = AudioComponentInstanceNew(audiounit_comp_io, &st->au);
 	if (ret)
 		goto out;
 

--- a/modules/audiounit/recorder.c
+++ b/modules/audiounit/recorder.c
@@ -106,8 +106,8 @@ static OSStatus input_callback(void *inRefCon,
 			      outNumberFrames,
 			      &abl_conv);
 	if (ret) {
-		debug("audiounit: record: AudioUnitRender convert error (%d)\n",
-		      ret);
+		debug("audiounit: record: "
+		      "AudioUnitRender convert error (%d)\n", ret);
 		return ret;
 	}
 
@@ -209,12 +209,14 @@ int audiounit_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (ret)
 		goto out;
 
-	ret = AudioUnitSetProperty(st->au_in, kAudioOutputUnitProperty_EnableIO,
+	ret = AudioUnitSetProperty(st->au_in,
+				   kAudioOutputUnitProperty_EnableIO,
 				   kAudioUnitScope_Input, inputBus,
 				   &enable, sizeof(enable));
 
 #if ! TARGET_OS_IPHONE
-	ret = AudioUnitSetProperty(st->au_in, kAudioOutputUnitProperty_EnableIO,
+	ret = AudioUnitSetProperty(st->au_in,
+				   kAudioOutputUnitProperty_EnableIO,
 				   kAudioUnitScope_Output, outputBus,
 				   &disable, sizeof(disable));
 	if (ret)

--- a/modules/audiounit/recorder.c
+++ b/modules/audiounit/recorder.c
@@ -151,7 +151,7 @@ static OSStatus input_callback(void *inRefCon,
 		return ret;
 	}
 
-	while(1) {
+	while (1) {
 		outNumberFrames = (st->conv_buf.nb_frames) * st->sampc_ratio;
 		if (outNumberFrames==0)
 			return noErr;


### PR DESCRIPTION
This PR is a proposal of an AUConverter resampler for audiounit module (recorder side).

The approach consists in using a specific AudioUnit for conversion (sub-type AUConverter).
The raw audio samples are captured (at hw sample rate) and then, the conversion is called

I did it in a really empirical way, mixing different "sources" (mainly from [here](http://dinhe.net/~aredridel/projects/audio/audioengine-1.4/ ) and [here](https://github.com/alfredh/baresip/tree/audiounit_resample2))

Tested successfully from OSX 10.13: auloop and calls with many combinations (44100 Hz -> 48000 Hz, 44100 Hz -> 8000 Hz, 48000 Hz -> 44100 Hz ...). 

Not tested from iOS...
