### PR TITLE
menu: sndcode should signal release of key

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -898,6 +898,9 @@ static int send_code(struct re_printf *pf, void *arg)
 	if (call) {
 		for (i = 0; i < str_len(carg->prm) && !err; i++) {
 			err = call_send_digit(call, carg->prm[i]);
+			if (!err) {
+				err = call_send_digit(call, KEYCODE_REL);
+			}
 		}
 	}
 


### PR DESCRIPTION
You currently can't issue DTMF via httpd or ctrl_tcp. With this patch you can.

Without this patch:
```
/sndcode 123
audio: send DTMF digit: '1'
audio: send DTMF digit: '2'
audio: send DTMF digit: '3'
audio: send DTMF digit end: '3'
```

With this patch:
```
/sndcode 123
audio: send DTMF digit: '1'
audio: send DTMF digit end: '1'
audio: send DTMF digit: '2'
audio: send DTMF digit end: '2'
audio: send DTMF digit: '3'
audio: send DTMF digit end: '3'
```

The "short" command that you can also issue over httpd will still not work. But changing that will also touch code that currently works in the console. Since "sndcode" is a good solution for httpd anyway I don't think that's a problem.