### PR TITLE
Improve mqtt module

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -162,3 +162,11 @@ ice_mode		full	# {full,lite}
 
 # sndfile #
 snd_path 		/tmp/
+
+# MQTT
+#mqtt_broker_host        sollentuna.example.com
+#mqtt_broker_port        1883
+#mqtt_broker_clientid    baresip01	#Has to be unique for each client, defaults to "baresip"
+#mqtt_broker_user        alfred	
+#mqtt_broker_password    Crocus
+#mqtt_basetopic          baresip/01	# May be uniqe for each client you want to control. Defaults to "baresip"

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -58,7 +58,7 @@ static void connect_callback(struct mosquitto *mosq, void *obj, int result)
 	(void)mqtt;
 
 	if (result != MOSQ_ERR_SUCCESS) {
-		warning("mqtt: could not connect to broker (%s)\n",
+		warning("mqtt: could not connect to broker (%s) \n",
 			mosquitto_strerror(result));
 		return;
 	}
@@ -94,8 +94,12 @@ static int module_init(void)
 		     mqttclientid, sizeof(mqttclientid));
 	conf_get_str(conf_cur(), "mqtt_basetopic",
 		     mqttbasetopic, sizeof(mqttbasetopic));
-	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command", mqttbasetopic);
+
+	info("mqtt: connecting to broker at %s:%d as %s topic %s\n", broker_host, broker_port, mqttclientid, mqttbasetopic);
+
+	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command/+", mqttbasetopic);
 	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),"/%s/event", mqttbasetopic);
+	info("mqtt: Publishing on %s, subscribing to %s\n", mqttpublishtopic, mqttsubscribetopic);
 	s_mqtt.basetopic = mqttbasetopic;
 	s_mqtt.subtopic = mqttsubscribetopic;
 	s_mqtt.pubtopic = mqttpublishtopic;

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -11,12 +11,16 @@
 
 
 static char broker_host[256] = "127.0.0.1";
-static char mqttusername[256] = "";	/* Authentication user name, default none */
-static char mqttpassword[256] = "";	/* Authentication password, default none */
-static char mqttclientid[256] = "baresip";	/* Client ID - default "baresip" */
-static char mqttbasetopic[128] = "baresip";	/* Base topic for MQTT - default "baresip" - i.e. /baresip/event */
-static char mqttpublishtopic[256]; 
-static char mqttsubscribetopic[256]; 
+/* Authentication user name, default none */
+static char mqttusername[256] = "";
+/* Authentication password, default none */
+static char mqttpassword[256] = "";
+/* Client ID - default "baresip" */
+static char mqttclientid[256] = "baresip";
+/* Base topic for MQTT - default "baresip" - i.e. /baresip/event */
+static char mqttbasetopic[128] = "baresip";
+static char mqttpublishtopic[256];
+static char mqttsubscribetopic[256];
 
 static uint32_t broker_port = 1883;
 
@@ -95,11 +99,15 @@ static int module_init(void)
 	conf_get_str(conf_cur(), "mqtt_basetopic",
 		     mqttbasetopic, sizeof(mqttbasetopic));
 
-	info("mqtt: connecting to broker at %s:%d as %s topic %s\n", broker_host, broker_port, mqttclientid, mqttbasetopic);
+	info("mqtt: connecting to broker at %s:%d as %s topic %s\n",
+		broker_host, broker_port, mqttclientid, mqttbasetopic);
 
-	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command/+", mqttbasetopic);
-	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),"/%s/event", mqttbasetopic);
-	info("mqtt: Publishing on %s, subscribing to %s\n", mqttpublishtopic, mqttsubscribetopic);
+	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command/+",
+		mqttbasetopic);
+	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),"/%s/event",
+		mqttbasetopic);
+	info("mqtt: Publishing on %s, subscribing to %s\n", mqttpublishtopic,
+		mqttsubscribetopic);
 	s_mqtt.basetopic = mqttbasetopic;
 	s_mqtt.subtopic = mqttsubscribetopic;
 	s_mqtt.pubtopic = mqttpublishtopic;
@@ -119,7 +127,8 @@ static int module_init(void)
 	mosquitto_connect_callback_set(s_mqtt.mosq, connect_callback);
 
 	if (*mqttusername != '\0') {
-		ret = mosquitto_username_pw_set(s_mqtt.mosq, mqttusername, mqttpassword);
+		ret = mosquitto_username_pw_set(s_mqtt.mosq, mqttusername,
+			mqttpassword);
 	}
 
 	ret = mosquitto_connect(s_mqtt.mosq, broker_host, broker_port,

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -106,7 +106,7 @@ static int module_init(void)
 		"/%s/command/+", mqttbasetopic);
 	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic), "/%s/event",
 		mqttbasetopic);
-	info("mqtt: Publishing on %s, subscribing to %s\n", 
+	info("mqtt: Publishing on %s, subscribing to %s\n",
 		mqttpublishtopic, mqttsubscribetopic);
 	s_mqtt.basetopic = mqttbasetopic;
 	s_mqtt.subtopic = mqttsubscribetopic;

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -11,6 +11,13 @@
 
 
 static char broker_host[256] = "127.0.0.1";
+static char mqttusername[256] = "";	/* Authentication user name, default none */
+static char mqttpassword[256] = "";	/* Authentication password, default none */
+static char mqttclientid[256] = "baresip";	/* Client ID - default "baresip" */
+static char mqttbasetopic[128] = "baresip";	/* Base topic for MQTT - default "baresip" - i.e. /baresip/event */
+static char mqttpublishtopic[256]; 
+static char mqttsubscribetopic[256]; 
+
 static uint32_t broker_port = 1883;
 
 static struct mqtt s_mqtt;
@@ -76,11 +83,26 @@ static int module_init(void)
 
 	mosquitto_lib_init();
 
+	/* Get configuration data */
 	conf_get_str(conf_cur(), "mqtt_broker_host",
 		     broker_host, sizeof(broker_host));
+	conf_get_str(conf_cur(), "mqtt_broker_user",
+		     mqttusername, sizeof(mqttusername));
+	conf_get_str(conf_cur(), "mqtt_broker_password",
+		     mqttpassword, sizeof(mqttpassword));
+	conf_get_str(conf_cur(), "mqtt_broker_clientid",
+		     mqttclientid, sizeof(mqttclientid));
+	conf_get_str(conf_cur(), "mqtt_basetopic",
+		     mqttbasetopic, sizeof(mqttbasetopic));
+	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command", mqttbasetopic);
+	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),"/%s/event", mqttbasetopic);
+	s_mqtt.basetopic = mqttbasetopic;
+	s_mqtt.subtopic = mqttsubscribetopic;
+	s_mqtt.pubtopic = mqttpublishtopic;
+
 	conf_get_u32(conf_cur(), "mqtt_broker_port", &broker_port);
 
-	s_mqtt.mosq = mosquitto_new("baresip", true, &s_mqtt);
+	s_mqtt.mosq = mosquitto_new(mqttclientid, true, &s_mqtt);
 	if (!s_mqtt.mosq) {
 		warning("mqtt: failed to create client instance\n");
 		return ENOMEM;
@@ -91,6 +113,10 @@ static int module_init(void)
 		return err;
 
 	mosquitto_connect_callback_set(s_mqtt.mosq, connect_callback);
+
+	if (*mqttusername != '\0') {
+		ret = mosquitto_username_pw_set(s_mqtt.mosq, mqttusername, mqttpassword);
+	}
 
 	ret = mosquitto_connect(s_mqtt.mosq, broker_host, broker_port,
 				keepalive);

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -102,12 +102,12 @@ static int module_init(void)
 	info("mqtt: connecting to broker at %s:%d as %s topic %s\n",
 		broker_host, broker_port, mqttclientid, mqttbasetopic);
 
-	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),"/%s/command/+",
+	snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),
+		"/%s/command/+", mqttbasetopic);
+	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic), "/%s/event",
 		mqttbasetopic);
-	snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),"/%s/event",
-		mqttbasetopic);
-	info("mqtt: Publishing on %s, subscribing to %s\n", mqttpublishtopic,
-		mqttsubscribetopic);
+	info("mqtt: Publishing on %s, subscribing to %s\n", 
+		mqttpublishtopic, mqttsubscribetopic);
 	s_mqtt.basetopic = mqttbasetopic;
 	s_mqtt.subtopic = mqttsubscribetopic;
 	s_mqtt.pubtopic = mqttpublishtopic;

--- a/modules/mqtt/mqtt.h
+++ b/modules/mqtt/mqtt.h
@@ -7,6 +7,9 @@
 
 struct mqtt {
 	struct mosquitto *mosq;
+	char *pubtopic;		/* Topic for publish */
+	char *subtopic;		/* Topic for subscribe */
+	char *basetopic;	/* Base topic */
 	struct tmr tmr;
 	int fd;
 };

--- a/modules/mqtt/publish.c
+++ b/modules/mqtt/publish.c
@@ -34,7 +34,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 	if (err)
 		goto out;
 
-	err = mqtt_publish_message(mqtt, "/baresip/event", "%H",
+	err = mqtt_publish_message(mqtt, mqtt->pubtopic, "%H",
 				   json_encode_odict, od);
 	if (err) {
 		warning("mqtt: failed to publish message (%m)\n", err);

--- a/modules/mqtt/subscribe.c
+++ b/modules/mqtt/subscribe.c
@@ -69,7 +69,7 @@ static void handle_command(struct mqtt *mqtt, const struct pl *msg)
 	   to the resp mbuf, send it back to broker */
 
 	re_snprintf(resp_topic, sizeof(resp_topic),
-		    "/baresip/command_resp/%s",
+		    "/%s/command_resp/%s", mqtt->basetopic,
 		    oe_tok ? oe_tok->u.str : "nil");
 
 	err = mqtt_publish_message(mqtt, resp_topic,
@@ -103,7 +103,7 @@ static void message_callback(struct mosquitto *mosq, void *obj,
 	msg.p = message->payload;
 	msg.l = message->payloadlen;
 
-	mosquitto_topic_matches_sub("/baresip/command", message->topic,
+	mosquitto_topic_matches_sub(mqtt->subtopic, message->topic,
 				    &match);
 	if (match) {
 		info("mqtt: got message for '%s' topic\n", message->topic);

--- a/modules/mqtt/subscribe.c
+++ b/modules/mqtt/subscribe.c
@@ -9,10 +9,6 @@
 #include <baresip.h>
 #include "mqtt.h"
 
-
-static const char *subscription_pattern = "/baresip/+";
-
-
 static int print_handler(const char *p, size_t size, void *arg)
 {
 	struct mbuf *mb = arg;
@@ -128,14 +124,14 @@ int mqtt_subscribe_start(struct mqtt *mqtt)
 {
 	int ret;
 
-	ret = mosquitto_subscribe(mqtt->mosq, NULL, subscription_pattern, 0);
+	ret = mosquitto_subscribe(mqtt->mosq, NULL, mqtt->subtopic, 0);
 	if (ret != MOSQ_ERR_SUCCESS) {
 		warning("mqtt: failed to subscribe (%s)\n",
 			mosquitto_strerror(ret));
 		return EPROTO;
 	}
 
-	info("mqtt: subscribed to pattern '%s'\n", subscription_pattern);
+	info("mqtt: subscribed to pattern '%s'\n", mqtt->subtopic);
 
 	return 0;
 }


### PR DESCRIPTION
The current mqtt module use the same client ID for all logins, making it impossible to have multiple baresip instances connected to the same broker. It also makes it impossible to separate instances when sending commands or reading events.

This patch adds configuration options for client ID, username, password as well as a base topic making it possible to control a cluster of Baresip instances on the same broker.

When configured, the base topic is used for both events and commands.

```
mqtt: connecting to broker at sollentuna.example.com:1883 as baresip01 topic baresip/olle01
mqtt: Publishing on /baresip/olle01/event, subscribing to /baresip/olle01/command/+
```

Tested with mosquitto. Original defaults are the same.