### PR TITLE
Added missing mem_ref on menu.message

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -409,6 +409,7 @@ struct message_lsnr;
 int  message_init(struct message **messagep);
 int  message_listen(struct message_lsnr **lsnrp, struct message *message,
 		    message_recv_h *h, void *arg);
+void message_stop_listening(struct message_lsnr *lsnrp);
 int  message_send(struct ua *ua, const char *peer, const char *msg,
 		  sip_resp_h *resph, void *arg);
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -1050,6 +1050,7 @@ static int module_close(void)
 		pthread_join(mod_obj.thread, NULL);
 	mod_obj.mq = mem_deref(mod_obj.mq);
 	aufilt_unregister(&vumeter);
+	message_stop_listening(mod_obj.message);
 	mod_obj.message = mem_deref(mod_obj.message);
 
 #ifdef USE_LIBNOTIFY

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -1262,7 +1262,6 @@ static int module_init(void)
 {
 	struct pl val;
 	int err;
-	struct message_lsnr *message;
 
 	/*
 	 * Read the config values
@@ -1313,11 +1312,10 @@ static int module_init(void)
 	if (err)
 		return err;
 
-	err = message_listen(&message, baresip_message(),
+	err = message_listen(&menu.message, baresip_message(),
 			     message_handler, NULL);
 	if (err)
 		return err;
-	menu.message = mem_ref(message);
 
 	return err;
 }

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -1262,6 +1262,7 @@ static int module_init(void)
 {
 	struct pl val;
 	int err;
+	struct message_lsnr *message;
 
 	/*
 	 * Read the config values
@@ -1312,10 +1313,11 @@ static int module_init(void)
 	if (err)
 		return err;
 
-	err = message_listen(&menu.message, baresip_message(),
+	err = message_listen(&message, baresip_message(),
 			     message_handler, NULL);
 	if (err)
 		return err;
+	menu.message = mem_ref(message);
 
 	return err;
 }

--- a/src/message.c
+++ b/src/message.c
@@ -147,7 +147,7 @@ int message_listen(struct message_lsnr **lsnrp, struct message *message,
 
 	list_append(&message->lsnrl, &lsnr->le, lsnr);
 	/* ref for list 8 */
-	mem_ref(lsnr); 
+	mem_ref(lsnr);
 
 	if (lsnrp)
 		*lsnrp = lsnr;

--- a/src/message.c
+++ b/src/message.c
@@ -146,7 +146,8 @@ int message_listen(struct message_lsnr **lsnrp, struct message *message,
 	lsnr->arg = arg;
 
 	list_append(&message->lsnrl, &lsnr->le, lsnr);
-	mem_ref(lsnr); //ref for list
+	/* ref for list 8 */
+	mem_ref(lsnr); 
 
 	if (lsnrp)
 		*lsnrp = lsnr;


### PR DESCRIPTION
message_listen constructs a message_lsnr using mem_zalloc (ref count 1)

Then it is added to the message->lsnrl list. 

When this list is cleaned up using list_flush (in re) then mem_deref is called on le->data (ref count 0)

Then in menu.c module_close mem_deref is called on menu.message (now we are accessing memory after free)

menu.c needs to mem-ref it's menu.message because the reference added by mem_zelloc is consumed by the list it is added to.
