### PR TITLE
Fix warnings at windows compilation

### DIFF
--- a/modules/vumeter/vumeter.c
+++ b/modules/vumeter/vumeter.c
@@ -84,7 +84,7 @@ static int audio_print_vu(struct re_printf *pf, double *level)
 
 	x = (*level + -AULEVEL_MIN) / -AULEVEL_MIN;
 
-	res = min(sizeof(buf) * x,
+	res = min((size_t)(sizeof(buf) * x),
 		  sizeof(buf)-1);
 
 	memset(buf, '=', res);

--- a/modules/winwave/play.c
+++ b/modules/winwave/play.c
@@ -164,7 +164,7 @@ static int write_stream_open(struct auplay_st *st,
 	wfmt.wFormatTag      = format;
 	wfmt.nChannels       = prm->ch;
 	wfmt.nSamplesPerSec  = prm->srate;
-	wfmt.wBitsPerSample  = st->sampsz * 8;
+	wfmt.wBitsPerSample  = (WORD)(st->sampsz * 8);
 	wfmt.nBlockAlign     = (prm->ch * wfmt.wBitsPerSample) / 8;
 	wfmt.nAvgBytesPerSec = wfmt.nSamplesPerSec * wfmt.nBlockAlign;
 	wfmt.cbSize          = 0;

--- a/modules/winwave/src.c
+++ b/modules/winwave/src.c
@@ -154,7 +154,7 @@ static int read_stream_open(struct ausrc_st *st, const struct ausrc_prm *prm,
 	wfmt.wFormatTag      = format;
 	wfmt.nChannels       = prm->ch;
 	wfmt.nSamplesPerSec  = prm->srate;
-	wfmt.wBitsPerSample  = st->sampsz * 8;
+	wfmt.wBitsPerSample  = (WORD)(st->sampsz * 8);
 	wfmt.nBlockAlign     = (prm->ch * wfmt.wBitsPerSample) / 8;
 	wfmt.nAvgBytesPerSec = wfmt.nSamplesPerSec * wfmt.nBlockAlign;
 	wfmt.cbSize          = 0;

--- a/src/account.c
+++ b/src/account.c
@@ -304,7 +304,7 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 
 		char expr[16] = "outbound";
 
-		expr[8] = i + 1 + 0x30;
+		expr[8] = (char)(i + 1 + 0x30);
 		expr[9] = '\0';
 
 		err |= param_dstr(&acc->outboundv[i], &aor->params, expr);

--- a/src/video.c
+++ b/src/video.c
@@ -251,7 +251,7 @@ static void vidqueue_poll(struct vtx *vtx, uint64_t jfs, uint64_t prev_jfs)
 	 * time [ms] * bitrate [kbps] / 8 = bytes
 	 */
 	bandwidth_kbps = vtx->video->cfg.bitrate / 1000;
-	burst = (1 + jfs - prev_jfs) * bandwidth_kbps / 4;
+	burst = (size_t)((1 + jfs - prev_jfs) * bandwidth_kbps / 4);
 
 	burst = min(burst, BURST_MAX);
 	sent  = 0;


### PR DESCRIPTION
This commit will fix warnings about possible data loss https://github.com/alfredh/baresip/issues/654#issuecomment-461546865
<details>
  <summary>Here is a full output:</summary>
<p>

```
3>------ Build started: Project: baresip-win32, Configuration: Debug Win32 ------
3>  account.c
3>  amr.c
3>  sdp.c
3>  auloop.c
3>  b2bua.c
3>  cons.c
3>  contact.c
3>  debug_cmd.c
3>  dshow.cpp
3>  echo.c
3>  g711.c
3>  httpd.c
3>  ice.c
3>  l16.c
3>  menu.c
3>  mwi.c
3>  natbd.c
3>  libnatpmp.c
3>  natpmp.c
3>  notifier.c
3>  presence.c
3>  publisher.c
3>  subscriber.c
3>  selfview.c
3>  sdes.c
3>  srtp.c
3>  stun.c
3>  turn.c
3>  uuid.c
3>  disp.c
3>  src.c
3>  vidbridge.c
3>  vidloop.c
3>  vumeter.c
3>  wincons.c
3>  play.c
3>  src.c
3>  winwave.c
3>  account.c
3>  aucodec.c
3>  audio.c
3>  aufilt.c
3>  auplay.c
3>  ausrc.c
3>  baresip.c
3>  bfcp.c
3>  call.c
3>  cmd.c
3>  conf.c
3>  config.c
3>  contact.c
3>  custom_hdrs.c
3>  h264.c
3>  log.c
3>  main.c
3>  mctrl.c
3>  mediadev.c
3>  menc.c
3>  message.c
3>  metric.c
3>  mnat.c
3>  module.c
3>  mos.c
3>  net.c
3>  play.c
3>  reg.c
3>  sdp.c
3>  sipreq.c
3>  stream.c
3>  timer.c
3>  ua.c
3>  ui.c
3>  vidcodec.c
3>  video.c
3>  vidfilt.c
3>  vidisp.c
3>  vidsrc.c
3>  static.c
3>  rtpext.c
3>  timestamp.c
3>  aulevel.c
3>  vidutil.c
3>  event.c
3>account.obj : warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/OPT:LBR' specification
3>     Creating library ..\..\Win32\Debug\bin\baresip-win32.lib and object ..\..\Win32\Debug\bin\baresip-win32.exp
3>  baresip.vcxproj -> C:\baresip\baresip\mk\win32\..\..\Win32\Debug\bin\baresip-win32.exe
3>  baresip.vcxproj -> ..\..\Win32\Debug\bin\baresip-win32.pdb (Full PDB)
========== Build: 3 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```
</p>
</details>

Warning `warning LNK4075: ignoring '/EDITANDCONTINUE' due to '/OPT:LBR' specification` is ok, because it does not affect run-time functionality. Fixing this will lead to making changes in re/rem/baresip MSVS project 