### PR TITLE
vidloop: update vidsrc

### DIFF
--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -636,11 +636,13 @@ static void update_vidsrc(void *arg)
 	struct config *cfg = conf_config();
 	int err;
 
-	tmr_start(&vl->tmr_update_src, 10, update_vidsrc, vl);
+	tmr_start(&vl->tmr_update_src, 100, update_vidsrc, vl);
 
-	if (!strcmp(vl->cfg.src_dev, cfg->video.src_dev))
+	if (!strcmp(vl->cfg.src_mod, cfg->video.src_mod) &&
+	    !strcmp(vl->cfg.src_dev, cfg->video.src_dev))
 		return;
 
+	strcpy(vl->cfg.src_mod,cfg->video.src_mod);
 	strcpy(vl->cfg.src_dev, cfg->video.src_dev);
 
 	size.w = cfg->video.width;

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -641,7 +641,6 @@ static void update_vidsrc(void *arg)
 	if (!strcmp(vl->cfg.src_dev, cfg->video.src_dev))
 		return;
 
-
 	strcpy(vl->cfg.src_dev, cfg->video.src_dev);
 
 	size.w = cfg->video.width;


### PR DESCRIPTION
This patch makes possible to switch between video sources without having to restart the loop.

Tested on Ubuntu16.04 and Win10. 