### PR TITLE
Readme and config example correction, httpd comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ The baresip project is using the 3-clause BSD license.
 ## Contributing
 
 Patches can be sent via Github
-[Pull-Requests](https://github.com/creytiv/baresip/pulls) or to the RE devel
+[Pull-Requests](https://github.com/alfredh/baresip/pulls) or to the RE devel
 [mailing-list](http://lists.creytiv.com/mailman/listinfo/re-devel).
 
 

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -141,9 +141,9 @@ module_app		vidloop.so
 # Module parameters
 
 # UI Modules parameters
-cons_listen			0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
+cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
 
-http_listen			0.0.0.0:8000 # httpd - HTTP Server
+http_listen		0.0.0.0:8000 # httpd - HTTP Server
 
 ctrl_tcp_listen		0.0.0.0:4444 # ctrl_tcp - TCP interface JSON
 
@@ -153,9 +153,9 @@ evdev_device		/dev/input/event0
 opus_bitrate		28000 # 6000-510000
 #opus_stereo		yes
 #opus_sprop_stereo	yes
-#opus_cbr			no
+#opus_cbr		no
 #opus_inband_fec	no
-#opus_dtx			no
+#opus_dtx		no
 #opus_mirror		no
 #opus_complexity	10
 #opus_application	audio # {voip,audio}
@@ -177,9 +177,9 @@ ice_mode		full # {full,lite}
 snd_path 		/tmp/
 
 # MQTT
-#mqtt_broker_host		sollentuna.example.com
-#mqtt_broker_port		1883
+#mqtt_broker_host	sollentuna.example.com
+#mqtt_broker_port	1883
 #mqtt_broker_clientid	baresip01 # Has to be unique for each client, defaults to "baresip"
-#mqtt_broker_user		alfred
+#mqtt_broker_user	alfred
 #mqtt_broker_password	Crocus
-#mqtt_basetopic			baresip/01 # May be uniqe for each client you want to control. Defaults to "baresip"
+#mqtt_basetopic		baresip/01 # May be uniqe for each client you want to control. Defaults to "baresip"

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -19,7 +19,7 @@ audio_alert		alsa,default
 #ausrc_srate		48000
 #auplay_srate		48000
 #ausrc_channels		0
-#auplay_channels		0
+#auplay_channels	0
 
 # Video
 #video_source		v4l2,/dev/video0
@@ -121,25 +121,44 @@ module_tmp		account.so
 # Application Modules
 
 module_app		auloop.so
+#module_app		b2bua.so
 module_app		contact.so
+#module_app		debug_cmd.so
+#module_app		dtmfio.so
+
+#module_app		echo.so
+#module_app		gtk.so
 module_app		menu.so
 #module_app		mwi.so
 #module_app		presence.so
 #module_app		syslog.so
+#module_app		mqtt.so
+#module_app		ctrl_tcp.so
 module_app		vidloop.so
-#module_app		gtk.so
 
 
 #------------------------------------------------------------------------------
 # Module parameters
 
+# UI Modules parameters
+cons_listen			0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
 
-cons_listen		0.0.0.0:5555
+http_listen			0.0.0.0:8000 # httpd - HTTP Server
+
+ctrl_tcp_listen		0.0.0.0:4444 # ctrl_tcp - TCP interface JSON
 
 evdev_device		/dev/input/event0
 
 # Opus codec parameters
 opus_bitrate		28000 # 6000-510000
+#opus_stereo		yes
+#opus_sprop_stereo	yes
+#opus_cbr			no
+#opus_inband_fec	no
+#opus_dtx			no
+#opus_mirror		no
+#opus_complexity	10
+#opus_application	audio # {voip,audio}
 
 # Selfview
 video_selfview		window # {window,pip}
@@ -148,8 +167,8 @@ video_selfview		window # {window,pip}
 # ICE
 ice_turn		no
 ice_debug		no
-ice_nomination		regular	# {regular,aggressive}
-ice_mode		full	# {full,lite}
+ice_nomination		regular # {regular,aggressive}
+ice_mode		full # {full,lite}
 
 # ZRTP
 #zrtp_hash		no  # Disable SDP zrtp-hash (not recommended)
@@ -158,9 +177,9 @@ ice_mode		full	# {full,lite}
 snd_path 		/tmp/
 
 # MQTT
-#mqtt_broker_host        sollentuna.example.com
-#mqtt_broker_port        1883
-#mqtt_broker_clientid    baresip01	#Has to be unique for each client, defaults to "baresip"
-#mqtt_broker_user        alfred	
-#mqtt_broker_password    Crocus
-#mqtt_basetopic          baresip/01	# May be uniqe for each client you want to control. Defaults to "baresip"
+#mqtt_broker_host		sollentuna.example.com
+#mqtt_broker_port		1883
+#mqtt_broker_clientid	baresip01 # Has to be unique for each client, defaults to "baresip"
+#mqtt_broker_user		alfred
+#mqtt_broker_password	Crocus
+#mqtt_basetopic			baresip/01 # May be uniqe for each client you want to control. Defaults to "baresip"

--- a/modules/httpd/httpd.c
+++ b/modules/httpd/httpd.c
@@ -12,15 +12,23 @@
  *
  * HTTP Server module for the User-Interface
  *
- * Open your favourite web browser and point it to http://127.0.0.1:8000/
  *
+ * Open your favourite web browser and point it to http://127.0.0.1:8000/
  * Example URLs:
+ *
  \verbatim
   http://127.0.0.1:8000?h                  -- Print the Help menu
   http://127.0.0.1:8000?d1234@target.com   -- Make an outgoing call
  \endverbatim
+ *
+ * The following options can be configured:
+ *
+ \verbatim
+  http_listen     0.0.0.0:8000         # IP-address and port to listen on
+ \endverbatim
  */
 
+enum {HTTP_PORT = 8000};
 
 static struct http_sock *httpsock;
 
@@ -98,6 +106,7 @@ static int html_print_raw(struct re_printf *pf, const struct pl *prm)
 			  "%H",
 			  handle_input, &params);
 }
+
 
 static void http_req_handler(struct http_conn *conn,
 			     const struct http_msg *msg, void *arg)
@@ -185,7 +194,7 @@ static int module_init(void)
 	int err;
 
 	if (conf_get_sa(conf_cur(), "http_listen", &laddr)) {
-		sa_set_str(&laddr, "0.0.0.0", 8000);
+		sa_set_str(&laddr, "0.0.0.0", HTTP_PORT);
 	}
 
 	err = http_listen(&httpsock, &laddr, http_req_handler, NULL);

--- a/src/config.c
+++ b/src/config.c
@@ -874,14 +874,14 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "# Module parameters\n");
 	(void)re_fprintf(f, "\n");
 
-	(void)re_fprintf(f, "\n");
-	(void)re_fprintf(f, "cons_listen\t\t0.0.0.0:5555\n");
+	(void)re_fprintf(f, "\n# UI Modules parameters\n");
+	(void)re_fprintf(f, "cons_listen\t\t0.0.0.0:5555 # cons - Console UI UDP/TCP sockets\n");
 
 	(void)re_fprintf(f, "\n");
-	(void)re_fprintf(f, "http_listen\t\t0.0.0.0:8000\n");
+	(void)re_fprintf(f, "http_listen\t\t0.0.0.0:8000 # httpd - HTTP Server\n");
 
 	(void)re_fprintf(f, "\n");
-	(void)re_fprintf(f, "ctrl_tcp_listen\t\t0.0.0.0:4444\n");
+	(void)re_fprintf(f, "ctrl_tcp_listen\t\t0.0.0.0:4444 # ctrl_tcp - TCP interface JSON\n");
 
 	(void)re_fprintf(f, "\n");
 	(void)re_fprintf(f, "evdev_device\t\t/dev/input/event0\n");

--- a/src/config.c
+++ b/src/config.c
@@ -875,13 +875,13 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "\n");
 
 	(void)re_fprintf(f, "\n# UI Modules parameters\n");
-	(void)re_fprintf(f, "cons_listen\t\t0.0.0.0:5555 # cons - Console UI UDP/TCP sockets\n");
+	(void)re_fprintf(f, "cons_listen\t\t0.0.0.0:5555 # cons\n");
 
 	(void)re_fprintf(f, "\n");
-	(void)re_fprintf(f, "http_listen\t\t0.0.0.0:8000 # httpd - HTTP Server\n");
+	(void)re_fprintf(f, "http_listen\t\t0.0.0.0:8000 # httpd - server\n");
 
 	(void)re_fprintf(f, "\n");
-	(void)re_fprintf(f, "ctrl_tcp_listen\t\t0.0.0.0:4444 # ctrl_tcp - TCP interface JSON\n");
+	(void)re_fprintf(f, "ctrl_tcp_listen\t\t0.0.0.0:4444 # ctrl_tcp\n");
 
 	(void)re_fprintf(f, "\n");
 	(void)re_fprintf(f, "evdev_device\t\t/dev/input/event0\n");


### PR DESCRIPTION
Hi Alfred,
I've suggested some very light changes. It helped me to more easily set the configuration. I added just an enum to httpd.c -> HTTP_PORT and comments so it resembles how the cons.c and ctrl_tcp.c looks and works.

Best regards
Roger (Swedish Radio) :)