### PR TITLE
Avcodec remove libx264

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -133,8 +133,8 @@ static struct vidcodec h264 = {
 	NULL,
 	avcodec_encode_update,
 	avcodec_encode,
-	decode_update,
-	decode_h264,
+	avcodec_decode_update,
+	avcodec_decode_h264,
 	h264_fmtp_enc,
 	h264_fmtp_cmp,
 };
@@ -147,8 +147,8 @@ static struct vidcodec h263 = {
 	NULL,
 	avcodec_encode_update,
 	avcodec_encode,
-	decode_update,
-	decode_h263,
+	avcodec_decode_update,
+	avcodec_decode_h263,
 	h263_fmtp_enc,
 	NULL,
 };
@@ -161,8 +161,8 @@ static struct vidcodec mpg4 = {
 	NULL,
 	avcodec_encode_update,
 	avcodec_encode,
-	decode_update,
-	decode_mpeg4,
+	avcodec_decode_update,
+	avcodec_decode_mpeg4,
 	mpg4_fmtp_enc,
 	NULL,
 };

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -38,7 +38,7 @@
  */
 
 
-const uint8_t h264_level_idc = 0x1f;
+static const uint8_t h264_level_idc = 0x1f;
 AVCodec *avcodec_h264enc;             /* optional; specified H.264 encoder */
 AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
 

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -7,9 +7,6 @@
 #include <rem.h>
 #include <baresip.h>
 #include <libavcodec/avcodec.h>
-#ifdef USE_X264
-#include <x264.h>
-#endif
 #include "h26x.h"
 #include "avcodec.h"
 
@@ -20,14 +17,8 @@
  * Video codecs using libavcodec
  *
  * This module implements H.263, H.264 and MPEG4 video codecs
- * using libavcodec from FFmpeg or libav projects, and libx264.
+ * using libavcodec from FFmpeg or libav projects.
  *
- * Build options:
- *
- \verbatim
-      $ make USE_X264=1    ; enable direct usage of libx264
-      $ make USE_X264=     ; use H.264 encoder from libavcodec
- \endverbatim
  *
  * Config options:
  *
@@ -140,12 +131,8 @@ static struct vidcodec h264 = {
 	"H264",
 	"packetization-mode=0",
 	NULL,
-	encode_update,
-#ifdef USE_X264
-	encode_x264,
-#else
-	encode,
-#endif
+	avcodec_encode_update,
+	avcodec_encode,
 	decode_update,
 	decode_h264,
 	h264_fmtp_enc,
@@ -158,8 +145,8 @@ static struct vidcodec h263 = {
 	"H263",
 	NULL,
 	NULL,
-	encode_update,
-	encode,
+	avcodec_encode_update,
+	avcodec_encode,
 	decode_update,
 	decode_h263,
 	h263_fmtp_enc,
@@ -172,8 +159,8 @@ static struct vidcodec mpg4 = {
 	"MP4V-ES",
 	NULL,
 	NULL,
-	encode_update,
-	encode,
+	avcodec_encode_update,
+	avcodec_encode,
 	decode_update,
 	decode_mpeg4,
 	mpg4_fmtp_enc,
@@ -184,14 +171,8 @@ static struct vidcodec mpg4 = {
 static int module_init(void)
 {
 	struct list *vidcodecl = baresip_vidcodecl();
-	char h264enc[64];
-	char h264dec[64];
-
-#ifdef USE_X264
-	debug("avcodec: x264 build %d\n", X264_BUILD);
-#else
-	debug("avcodec: using libavcodec H.264 encoder\n");
-#endif
+	char h264enc[64] = "libx264";
+	char h264dec[64] = "h264";
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
 	avcodec_init();
@@ -201,23 +182,21 @@ static int module_init(void)
 	avcodec_register_all();
 #endif
 
-	if (0 == conf_get_str(conf_cur(), "avcodec_h264dec",
-			      h264dec, sizeof(h264dec))) {
+	conf_get_str(conf_cur(), "avcodec_h264enc", h264enc, sizeof(h264enc));
+	conf_get_str(conf_cur(), "avcodec_h264dec", h264dec, sizeof(h264dec));
 
-		info("avcodec: using h264 decoder by name (%s)\n", h264dec);
+	avcodec_h264enc = avcodec_find_encoder_by_name(h264enc);
+	if (!avcodec_h264enc) {
+		warning("avcodec: h264 encoder not found (%s)\n", h264enc);
+	}
 
-		avcodec_h264dec = avcodec_find_decoder_by_name(h264dec);
-		if (!avcodec_h264dec) {
-			warning("avcodec: h264 decoder not found (%s)\n",
-				h264dec);
-			return ENOENT;
-		}
+	avcodec_h264dec = avcodec_find_decoder_by_name(h264dec);
+	if (!avcodec_h264dec) {
+		warning("avcodec: h264 decoder not found (%s)\n", h264dec);
+	}
+
+	if (avcodec_h264enc || avcodec_h264dec)
 		vidcodec_register(vidcodecl, &h264);
-	}
-	else {
-		if (avcodec_find_decoder(AV_CODEC_ID_H264))
-			vidcodec_register(vidcodecl, &h264);
-	}
 
 	if (avcodec_find_decoder(AV_CODEC_ID_H263))
 		vidcodec_register(vidcodecl, &h263);
@@ -225,17 +204,13 @@ static int module_init(void)
 	if (avcodec_find_decoder(AV_CODEC_ID_MPEG4))
 		vidcodec_register(vidcodecl, &mpg4);
 
-	if (0 == conf_get_str(conf_cur(), "avcodec_h264enc",
-			      h264enc, sizeof(h264enc))) {
-
-		info("avcodec: using h264 encoder by name (%s)\n", h264enc);
-
-		avcodec_h264enc = avcodec_find_encoder_by_name(h264enc);
-		if (!avcodec_h264enc) {
-			warning("avcodec: h264 encoder not found (%s)\n",
-				h264enc);
-			return ENOENT;
-		}
+	if (avcodec_h264enc) {
+		info("avcodec: using H.264 encoder '%s' -- %s\n",
+		     avcodec_h264enc->name, avcodec_h264enc->long_name);
+	}
+	if (avcodec_h264dec) {
+		info("avcodec: using H.264 decoder '%s' -- %s\n",
+		     avcodec_h264dec->name, avcodec_h264dec->long_name);
 	}
 
 	return 0;

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -24,6 +24,11 @@
 #endif
 
 
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 20, 100)
+#define av_frame_alloc avcodec_alloc_frame
+#endif
+
+
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 63, 100)
 #define avcodec_free_context(ctx)				\
 								\

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -39,6 +39,17 @@
 #endif
 
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 37, 100)
+#define av_packet_free(pkt)			\
+						\
+	if (*(pkt)) {				\
+						\
+		av_free_packet(*(pkt));		\
+		av_freep((pkt));		\
+	}
+#endif
+
+
 extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
 

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -24,6 +24,16 @@
 #endif
 
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 63, 100)
+#define avcodec_free_context(ctx)				\
+								\
+	if (*(ctx)) {						\
+		avcodec_close(*(ctx));				\
+		av_freep((ctx));				\
+	}
+#endif
+
+
 extern const uint8_t h264_level_idc;
 extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -39,7 +39,6 @@
 #endif
 
 
-extern const uint8_t h264_level_idc;
 extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
 

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -64,18 +64,14 @@ int avcodec_encode(struct videnc_state *st, bool update,
 
 struct viddec_state;
 
-int decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		  const char *fmtp);
-int decode_h263(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_update(struct viddec_state **vdsp,
+			  const struct vidcodec *vc, const char *fmtp);
+int avcodec_decode_h263(struct viddec_state *st, struct vidframe *frame,
 		bool *intra, bool eof, uint16_t seq, struct mbuf *src);
-int decode_h264(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_h264(struct viddec_state *st, struct vidframe *frame,
 		bool *intra, bool eof, uint16_t seq, struct mbuf *src);
-int decode_mpeg4(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_mpeg4(struct viddec_state *st, struct vidframe *frame,
 		 bool *intra, bool eof, uint16_t seq, struct mbuf *src);
-
-
-int decode_sdpparam_h264(struct videnc_state *st, const struct pl *name,
-			 const struct pl *val);
 
 
 int avcodec_resolve_codecid(const char *s);

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -35,15 +35,12 @@ extern AVCodec *avcodec_h264dec;
 
 struct videnc_state;
 
-int encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
-		  struct videnc_param *prm, const char *fmtp,
-		  videnc_packet_h *pkth, void *arg);
-int encode(struct videnc_state *st, bool update, const struct vidframe *frame,
-	   uint64_t timestamp);
-#ifdef USE_X264
-int encode_x264(struct videnc_state *st, bool update,
-		const struct vidframe *frame, uint64_t timestamp);
-#endif
+int avcodec_encode_update(struct videnc_state **vesp,
+			  const struct vidcodec *vc,
+			  struct videnc_param *prm, const char *fmtp,
+			  videnc_packet_h *pkth, void *arg);
+int avcodec_encode(struct videnc_state *st, bool update,
+		   const struct vidframe *frame, uint64_t timestamp);
 
 
 /*

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -74,11 +74,8 @@ static void destructor(void *arg)
 
 	mem_deref(st->mb);
 
-	if (st->ctx) {
-		if (st->ctx->codec)
-			avcodec_close(st->ctx);
-		av_free(st->ctx);
-	}
+	if (st->ctx)
+		avcodec_free_context(&st->ctx);
 
 	if (st->pict)
 		av_free(st->pict);
@@ -108,11 +105,7 @@ static int init_decoder(struct viddec_state *st, const char *name)
 
 	st->ctx = avcodec_alloc_context3(st->codec);
 
-#if LIBAVUTIL_VERSION_INT >= ((52<<16)+(20<<8)+100)
 	st->pict = av_frame_alloc();
-#else
-	st->pict = avcodec_alloc_frame();
-#endif
 
 	if (!st->ctx || !st->pict)
 		return ENOMEM;

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -124,8 +124,8 @@ static int init_decoder(struct viddec_state *st, const char *name)
 }
 
 
-int decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		  const char *fmtp)
+int avcodec_decode_update(struct viddec_state **vdsp,
+			  const struct vidcodec *vc, const char *fmtp)
 {
 	struct viddec_state *st;
 	int err = 0;
@@ -265,7 +265,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame)
 }
 
 
-int decode_h264(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_h264(struct viddec_state *st, struct vidframe *frame,
 		bool *intra, bool marker, uint16_t seq, struct mbuf *src)
 {
 	struct h264_hdr h264_hdr;
@@ -410,7 +410,7 @@ int decode_h264(struct viddec_state *st, struct vidframe *frame,
 }
 
 
-int decode_mpeg4(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_mpeg4(struct viddec_state *st, struct vidframe *frame,
 		 bool *intra, bool marker, uint16_t seq, struct mbuf *src)
 {
 	int err;
@@ -464,7 +464,7 @@ int decode_mpeg4(struct viddec_state *st, struct vidframe *frame,
 }
 
 
-int decode_h263(struct viddec_state *st, struct vidframe *frame,
+int avcodec_decode_h263(struct viddec_state *st, struct vidframe *frame,
 		bool *intra, bool marker, uint16_t seq, struct mbuf *src)
 {
 	struct h263_hdr hdr;

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -500,8 +500,8 @@ int avcodec_encode(struct videnc_state *st, bool update,
 
 	av_init_packet(pkt);
 
-	pkt.data = st->mb->buf;
-	pkt.size = (int)st->mb->size;
+	pkt->data = st->mb->buf;
+	pkt->size = (int)st->mb->size;
 
 	ret = avcodec_encode_video2(st->ctx, &pkt, pict, &got_packet);
 	if (ret < 0) {
@@ -509,7 +509,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 		goto out;
 	}
 
-	mbuf_set_end(st->mb, pkt.size);
+	mbuf_set_end(st->mb, pkt->size);
 #endif
 
 	if (!got_packet)

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -503,7 +503,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 	pkt->data = st->mb->buf;
 	pkt->size = (int)st->mb->size;
 
-	ret = avcodec_encode_video2(st->ctx, &pkt, pict, &got_packet);
+	ret = avcodec_encode_video2(st->ctx, pkt, pict, &got_packet);
 	if (ret < 0) {
 		err = EBADMSG;
 		goto out;

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -28,7 +28,6 @@ struct videnc_state {
 	AVCodec *codec;
 	AVCodecContext *ctx;
 	struct mbuf *mb;
-	size_t sz_max; /* todo: figure out proper buffer size */
 	struct mbuf *mb_frag;
 	struct videnc_param encprm;
 	struct vidsz encsize;
@@ -377,7 +376,6 @@ int avcodec_encode_update(struct videnc_state **vesp,
 		goto out;
 	}
 
-	st->sz_max = st->mb->size;
 	st->fmt = -1;
 
 	err = init_encoder(st);
@@ -502,16 +500,16 @@ int avcodec_encode(struct videnc_state *st, bool update,
 
 	av_init_packet(pkt);
 
-	avpkt.data = st->mb->buf;
-	avpkt.size = (int)st->mb->size;
+	pkt.data = st->mb->buf;
+	pkt.size = (int)st->mb->size;
 
-	ret = avcodec_encode_video2(st->ctx, &avpkt, pict, &got_packet);
+	ret = avcodec_encode_video2(st->ctx, &pkt, pict, &got_packet);
 	if (ret < 0) {
 		err = EBADMSG;
 		goto out;
 	}
 
-	mbuf_set_end(st->mb, avpkt.size);
+	mbuf_set_end(st->mb, pkt.size);
 #endif
 
 	if (!got_packet)

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -166,6 +166,13 @@ static int open_encoder(struct videnc_state *st,
 	st->ctx->time_base.num = 1;
 	st->ctx->time_base.den = prm->fps;
 
+	if (0 == strcmp(st->codec->name, "libx264")) {
+
+		av_opt_set(st->ctx->priv_data, "profile", "baseline", 0);
+		av_opt_set(st->ctx->priv_data, "preset", "ultrafast", 0);
+		av_opt_set(st->ctx->priv_data, "tune", "zerolatency", 0);
+	}
+
 	/* params to avoid libavcodec/x264 default preset error */
 	if (st->codec_id == AV_CODEC_ID_H264) {
 

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -242,7 +242,7 @@ static int open_encoder(struct videnc_state *st,
 }
 
 
-int decode_sdpparam_h264(struct videnc_state *st, const struct pl *name,
+static int decode_sdpparam_h264(struct videnc_state *st, const struct pl *name,
 			 const struct pl *val)
 {
 	if (0 == pl_strcasecmp(name, "packetization-mode")) {

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -160,11 +160,7 @@ static int open_encoder(struct videnc_state *st,
 
 	st->ctx = avcodec_alloc_context3(st->codec);
 
-#if LIBAVUTIL_VERSION_INT >= ((52<<16)+(20<<8)+100)
 	st->pict = av_frame_alloc();
-#else
-	st->pict = avcodec_alloc_frame();
-#endif
 
 	if (!st->ctx || !st->pict) {
 		err = ENOMEM;
@@ -463,15 +459,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 	if (update) {
 		debug("avcodec: encoder picture update\n");
 		st->pict->key_frame = 1;
-#ifdef FF_I_TYPE
-		st->pict->pict_type = FF_I_TYPE;  /* Infra Frame */
-#else
 		st->pict->pict_type = AV_PICTURE_TYPE_I;
-#endif
-	}
-	else {
-		st->pict->key_frame = 0;
-		st->pict->pict_type = 0;
 	}
 
 	mbuf_rewind(st->mb);

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -75,14 +75,8 @@ static void destructor(void *arg)
 	mem_deref(st->mb);
 	mem_deref(st->mb_frag);
 
-	if (st->ctx) {
-		if (st->ctx->codec)
-			avcodec_close(st->ctx);
-#if LIBAVUTIL_VERSION_INT >= ((51<<16)+(8<<8)+0)
-		av_opt_free(st->ctx);
-#endif
-		av_free(st->ctx);
-	}
+	if (st->ctx)
+		avcodec_free_context(&st->ctx);
 
 	if (st->pict)
 		av_free(st->pict);
@@ -158,14 +152,8 @@ static int open_encoder(struct videnc_state *st,
 {
 	int err = 0;
 
-	if (st->ctx) {
-		if (st->ctx->codec)
-			avcodec_close(st->ctx);
-#if LIBAVUTIL_VERSION_INT >= ((51<<16)+(8<<8)+0)
-		av_opt_free(st->ctx);
-#endif
-		av_free(st->ctx);
-	}
+	if (st->ctx)
+		avcodec_free_context(&st->ctx);
 
 	if (st->pict)
 		av_free(st->pict);
@@ -243,15 +231,8 @@ static int open_encoder(struct videnc_state *st,
 
  out:
 	if (err) {
-		if (st->ctx) {
-			if (st->ctx->codec)
-				avcodec_close(st->ctx);
-#if LIBAVUTIL_VERSION_INT >= ((51<<16)+(8<<8)+0)
-			av_opt_free(st->ctx);
-#endif
-			av_free(st->ctx);
-			st->ctx = NULL;
-		}
+		if (st->ctx)
+			avcodec_free_context(&st->ctx);
 
 		if (st->pict) {
 			av_free(st->pict);

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -492,7 +492,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 		if (err)
 			return err;
 	} while (0);
-#elif LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(54, 1, 0)
+#else
 	do {
 		AVPacket avpkt;
 		int got_packet;
@@ -514,22 +514,6 @@ int avcodec_encode(struct videnc_state *st, bool update,
 		pts = avpkt.dts;
 
 	} while (0);
-#else
-	ret = avcodec_encode_video(st->ctx, st->mb->buf,
-				   (int)st->mb->size, st->pict);
-	if (ret < 0 )
-		return EBADMSG;
-
-	/* todo: figure out proper buffer size */
-	if (ret > (int)st->sz_max) {
-		debug("avcodec: grow encode buffer %u --> %d\n",
-		      st->sz_max, ret);
-		st->sz_max = ret;
-	}
-
-	mbuf_set_end(st->mb, ret);
-
-	pts = st->pict->pts;
 #endif
 
 	ts = video_calc_rtp_timestamp_fix(pts);

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -163,6 +163,7 @@ static int open_encoder(struct videnc_state *st,
 	st->ctx->pix_fmt   = pix_fmt;
 	st->ctx->time_base.num = 1;
 	st->ctx->time_base.den = prm->fps;
+	st->ctx->gop_size = 10 * prm->fps;
 
 	if (0 == str_cmp(st->codec->name, "libx264")) {
 

--- a/modules/avcodec/h263.c
+++ b/modules/avcodec/h263.c
@@ -7,9 +7,6 @@
 #include <rem.h>
 #include <baresip.h>
 #include <libavcodec/avcodec.h>
-#ifdef USE_X264
-#include <x264.h>
-#endif
 #include "h26x.h"
 #include "avcodec.h"
 

--- a/modules/avcodec/module.mk
+++ b/modules/avcodec/module.mk
@@ -4,18 +4,10 @@
 # Copyright (C) 2010 Creytiv.com
 #
 
-USE_X264 := $(shell [ -f $(SYSROOT)/include/x264.h ] || \
-	[ -f $(SYSROOT)/local/include/x264.h ] || \
-	[ -f $(SYSROOT_ALT)/include/x264.h ] && echo "yes")
-
 MOD		:= avcodec
 $(MOD)_SRCS	+= avcodec.c h263.c encode.c decode.c
 $(MOD)_LFLAGS	+= -lavcodec -lavutil
 CFLAGS          += -DUSE_AVCODEC
-ifneq ($(USE_X264),)
-CFLAGS          += -DUSE_X264
-$(MOD)_LFLAGS	+= -lx264
-endif
 $(MOD)_CFLAGS	+= -isystem /usr/local/include
 
 include mk/mod.mk


### PR DESCRIPTION
the main reason for this is that libx264 is GPL and we dont want to link to GPL code.

avcodec.so will now use only FFmpeg libavcodec for both encoding and decoding.

Platforms:

- [x] Debian 8
- [x] Debian 9
- [x] OpenBSD 6.4
- [x] Ubuntu 16.04
- [x] OSX 10.12

Things to fix:

- [x] Too many keyframes


