### PR TITLE
Count ua references after UA_EVENT_SHUTDOWN in ua_destroy

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -717,7 +717,7 @@ int  ua_update_account(struct ua *ua);
 int  ua_register(struct ua *ua);
 void ua_unregister(struct ua *ua);
 bool ua_isregistered(const struct ua *ua);
-void ua_destroy(struct ua *ua);
+unsigned ua_destroy(struct ua *ua);
 void ua_pub_gruu_set(struct ua *ua, const struct pl *pval);
 const char     *ua_aor(const struct ua *ua);
 const char     *ua_cuser(const struct ua *ua);


### PR DESCRIPTION
Resolves #701

Count ua references after UA_EVENT_SHUTDOWN in case that triggers clean-up in other modules.