### PR TITLE
call: reset streams on call hold

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1175,6 +1175,7 @@ static int sipsess_offer_handler(struct mbuf **descp,
 {
 	const bool got_offer = (0 != mbuf_get_left(msg->mb));
 	struct call *call = arg;
+	struct le *le;
 	int err;
 
 	MAGIC_CHECK(call);
@@ -1194,6 +1195,9 @@ static int sipsess_offer_handler(struct mbuf **descp,
 		err = update_media(call);
 		if (err)
 			return err;
+
+		FOREACH_STREAM
+			stream_reset(le->data);
 	}
 
 	/* Encode SDP Answer */

--- a/src/stream.c
+++ b/src/stream.c
@@ -645,6 +645,7 @@ void stream_hold(struct stream *s, bool hold)
 
 	s->hold = hold;
 	sdp_media_set_ldir(s->sdp, hold ? SDP_SENDONLY : SDP_SENDRECV);
+	stream_reset(s);
 }
 
 


### PR DESCRIPTION
The audio data in the jitter buffer has to be flushed when putting a call into
on hold state. Otherwise it is played on the playback device after the call is
resumed.