### PR TITLE
webrtc_aec module: added pthread.h include to .cpp files

### DIFF
--- a/modules/webrtc_aec/aec.cpp
+++ b/modules/webrtc_aec/aec.cpp
@@ -7,9 +7,11 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
 #include "modules/audio_processing/aec/echo_cancellation.h"
 #include "aec.h"
-
 
 /**
  * @defgroup webrtc_aec webrtc_aec

--- a/modules/webrtc_aec/decode.cpp
+++ b/modules/webrtc_aec/decode.cpp
@@ -7,6 +7,9 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
 #include "modules/audio_processing/aec/echo_cancellation.h"
 #include "aec.h"
 

--- a/modules/webrtc_aec/encode.cpp
+++ b/modules/webrtc_aec/encode.cpp
@@ -8,6 +8,9 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
 #include "modules/audio_processing/aec/echo_cancellation.h"
 #include "aec.h"
 


### PR DESCRIPTION
WIthout pthread.h includes, Android clang++ compiler didn't find pthread related functions.