### PR TITLE
audio: handle marker bit in stream.c

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -882,11 +882,6 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 			return;
 	}
 
-	if (hdr->m) {
-		stream_reset(a->strm);
-		debug("audio: rtp marker bit set\n");
-	}
-
 	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
 	for (i=0; i<extc; i++) {
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -252,6 +252,10 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 	if (!(sdp_media_ldir(s->sdp) & SDP_RECVONLY))
 		return;
 
+	/* The marker bit indicates the beginning of a talkspurt. */
+	if (hdr->m && s->type == MEDIA_AUDIO)
+		flush = true;
+
 	metric_add_packet(&s->metric_rx, mbuf_get_left(mb));
 
 	if (!s->rtp_estab) {


### PR DESCRIPTION
when audio stream is receiving RTP with marker bit set, the following
should happen:

1. flush jitter buffer (re-ordering buffer)
2. flush aubuf for playback.

@cspiel1 could you please test this patch ?

