### PR TITLE
Update MSVS project (Remove mos.c)

### DIFF
--- a/mk/win32/baresip.vcxproj
+++ b/mk/win32/baresip.vcxproj
@@ -185,7 +185,6 @@
     <ClCompile Include="..\..\src\metric.c" />
     <ClCompile Include="..\..\src\mnat.c" />
     <ClCompile Include="..\..\src\module.c" />
-    <ClCompile Include="..\..\src\mos.c" />
     <ClCompile Include="..\..\src\net.c" />
     <ClCompile Include="..\..\src\play.c" />
     <ClCompile Include="..\..\src\reg.c" />

--- a/mk/win32/baresip.vcxproj.filters
+++ b/mk/win32/baresip.vcxproj.filters
@@ -188,9 +188,6 @@
     <ClCompile Include="..\..\src\module.c">
       <Filter>src</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\mos.c">
-      <Filter>src</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\net.c">
       <Filter>src</Filter>
     </ClCompile>


### PR DESCRIPTION
Hello!
In this PR https://github.com/alfredh/baresip/pull/739 `src/mos.c` file was removed from repo but not from MSVS project. This PR removes it from project