### PR TITLE
Allow CALL_CLOSED to be raised when call_id is not set.

### DIFF
--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -275,7 +275,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 	err = odict_entry_add(od, "event", ODICT_BOOL, true);
 	err |= event_encode_dict(od, ua, ev, call, prm);
 	if (err)
+	{
+		warning("ctrl_tcp: failed to encode event (%m)\n", err);
 		goto out;
+	}
 
 	err = json_encode_odict(&pf, od);
 	if (err) {

--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -274,8 +274,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	err = odict_entry_add(od, "event", ODICT_BOOL, true);
 	err |= event_encode_dict(od, ua, ev, call, prm);
-	if (err)
-	{
+	if (err) {
 		warning("ctrl_tcp: failed to encode event (%m)\n", err);
 		goto out;
 	}

--- a/src/event.c
+++ b/src/event.c
@@ -136,11 +136,12 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 		err |= odict_entry_add(od, "direction", ODICT_STRING, dir);
 		err |= odict_entry_add(od, "peeruri",
 				       ODICT_STRING, call_peeruri(call));
-					   
+
 		call_identifier = call_id(call);
-		if(call_identifier)
+		if (call_identifier)
 		{
-			err |= odict_entry_add(od, "id", ODICT_STRING, call_identifier);
+			err |= odict_entry_add(od, "id", ODICT_STRING,
+						   call_identifier);
 		}
 
 		if (err)

--- a/src/event.c
+++ b/src/event.c
@@ -129,13 +129,20 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 	if (call) {
 
 		const char *dir;
+		const char *call_identifier;
 
 		dir = call_is_outgoing(call) ? "outgoing" : "incoming";
 
 		err |= odict_entry_add(od, "direction", ODICT_STRING, dir);
 		err |= odict_entry_add(od, "peeruri",
 				       ODICT_STRING, call_peeruri(call));
-		err |= odict_entry_add(od, "id", ODICT_STRING, call_id(call));
+					   
+		call_identifier = call_id(call);
+		if(call_identifier)
+		{
+			err |= odict_entry_add(od, "id", ODICT_STRING, call_identifier);
+		}
+
 		if (err)
 			goto out;
 	}

--- a/src/event.c
+++ b/src/event.c
@@ -138,8 +138,7 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 				       ODICT_STRING, call_peeruri(call));
 
 		call_identifier = call_id(call);
-		if (call_identifier)
-		{
+		if (call_identifier) {
 			err |= odict_entry_add(od, "id", ODICT_STRING,
 						   call_identifier);
 		}


### PR DESCRIPTION
Fix for #747