### PR TITLE
menu: sndcode should signal release of key

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -899,6 +899,9 @@ static int send_code(struct re_printf *pf, void *arg)
 		for (i = 0; i < str_len(carg->prm) && !err; i++) {
 			err = call_send_digit(call, carg->prm[i]);
 		}
+		if (!err) {
+			err = call_send_digit(call, KEYCODE_REL);
+		}
 	}
 
 	return err;


### PR DESCRIPTION
Coming back on PR #628. The DTMFs arrive, but the last sent digit really needs the `KEYCODE_REL` in order for the far end to receive the DTMF end marker. I changed this PR to the suggestion you made in that PR :-)