### PR TITLE
mnat: add wait_connected flag

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1236,6 +1236,7 @@ struct mnat {
 	struct le le;
 	const char *id;
 	const char *ftag;
+	bool wait_connected;
 	mnat_sess_h *sessh;
 	mnat_media_h *mediah;
 	mnat_update_h *updateh;

--- a/modules/ice/ice.c
+++ b/modules/ice/ice.c
@@ -955,6 +955,7 @@ static int update(struct mnat_sess *sess)
 static struct mnat mnat_ice = {
 	.id      = "ice",
 	.ftag    = "+sip.ice",
+	.wait_connected = true,
 	.sessh   = session_alloc,
 	.mediah  = media_alloc,
 	.updateh = update,


### PR DESCRIPTION
this is a proposal to add a new flag to the mnat struct, called `bool wait_connected`

the purpose is to control when the media-stream should be started
(audio and video stream). if the flag is set, the core will not start audio/video
until for example ICE is connected, meaning that it has a working candidate pair.

below is the list of all MEDIANAT modules and the suggested value
of the wait_connected flag:

| Medianat | wait_connected |
| ---- | ---- |
| stun | no |
| turn | no |
| ice | yes |
| natpmp | no |
| pcp | no |

a similar flag will also be added to the MEDIAENC struct, e.g. `bool wait_secure`
