### PR TITLE
menc: add wait_secure flag

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -604,6 +604,7 @@ struct menc {
 	struct le le;
 	const char *id;
 	const char *sdp_proto;
+	bool wait_secure;
 	menc_sess_h *sessh;
 	menc_media_h *mediah;
 };

--- a/modules/dtls_srtp/dtls_srtp.c
+++ b/modules/dtls_srtp/dtls_srtp.c
@@ -433,6 +433,7 @@ static int media_alloc(struct menc_media **mp, struct menc_sess *sess,
 static struct menc dtls_srtp = {
 	.id        = "dtls_srtp",
 	.sdp_proto = "UDP/TLS/RTP/SAVPF",
+	.wait_secure = true,
 	.sessh     = session_alloc,
 	.mediah    = media_alloc
 };


### PR DESCRIPTION
this patch adds a flag `bool wait_secure` to the mediaenc struct

the purpose is to control when the media-stream should start.
if the flag is false, the media stream will start when the SIP session
is established. if the flag is true, the media stream will start when
the menc is secure.

for example DTLS-SRTP has an async handshake after the SIP session
is established, so the flag should be set to true here.

here is a list of Mediaenc modules and the suggested flag value:

| Module | wait_secure |
| --- | --- |
| srtp | no |
| zrtp | no |
| dtls_srtp | yes |
