### PR TITLE
webrtc interop

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -367,6 +367,7 @@ int  stream_jbuf_reset(struct stream *strm,
 		       uint32_t frames_min, uint32_t frames_max);
 void stream_set_secure(struct stream *strm, bool secure);
 int  stream_start(const struct stream *strm);
+bool stream_is_ready(const struct stream *strm);
 
 
 /*

--- a/src/stream.c
+++ b/src/stream.c
@@ -22,6 +22,15 @@ enum {
 };
 
 
+static bool mnat_ready(const struct stream *strm)
+{
+	if (strm->mnat && strm->mnat->wait_connected)
+		return strm->mnat_connected;
+	else
+		return true;
+}
+
+
 static void stream_close(struct stream *strm, int err)
 {
 	stream_error_h *errorh = strm->errorh;
@@ -417,6 +426,7 @@ static void mnat_connected_handler(const struct sa *raddr1,
 				   const struct sa *raddr2, void *arg)
 {
 	struct stream *strm = arg;
+	int err;
 
 	info("stream: mnat connected: raddr %J %J\n", raddr1, raddr2);
 
@@ -428,6 +438,12 @@ static void mnat_connected_handler(const struct sa *raddr1,
 		strm->raddr_rtcp = *raddr2;
 
 	strm->mnat_connected = true;
+
+	if (strm->mencs) {
+		err = start_mediaenc(strm);
+		if (err)
+			stream_close(strm, err);
+	}
 }
 
 
@@ -517,7 +533,7 @@ int stream_alloc(struct stream **sp, const struct stream_param *prm,
 		s->mnat = mnat;
 		err = mnat->mediah(&s->mns, mnat_sess,
 				   rtp_sock(s->rtp),
-				   rtcp_sock(s->rtp),
+				   cfg->rtcp_mux ? NULL : rtcp_sock(s->rtp),
 				   s->sdp, mnat_connected_handler, s);
 		if (err)
 			goto out;
@@ -526,9 +542,13 @@ int stream_alloc(struct stream **sp, const struct stream_param *prm,
 	if (menc && s->rtp) {
 		s->menc  = menc;
 		s->mencs = mem_ref(menc_sess);
-		err = start_mediaenc(s);
-		if (err)
-			goto out;
+
+		if (mnat_ready(s)) {
+
+			err = start_mediaenc(s);
+			if (err)
+				goto out;
+		}
 	}
 
 	if (err)
@@ -579,6 +599,11 @@ int stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 	if (s->hold)
 		return 0;
 
+	if (!stream_is_ready(s)) {
+		warning("stream: send: not ready\n");
+		return EINTR;
+	}
+
 	metric_add_packet(&s->metric_tx, mbuf_get_left(mb));
 
 	if (pt < 0)
@@ -620,7 +645,10 @@ static void stream_remote_set(struct stream *s)
 	else
 		sdp_media_raddr_rtcp(s->sdp, &s->raddr_rtcp);
 
-	stream_start(s);
+	if (stream_is_ready(s)) {
+
+		stream_start(s);
+	}
 }
 
 
@@ -637,6 +665,8 @@ void stream_update(struct stream *s)
 	if (!s)
 		return;
 
+	info("stream: update\n");
+
 	fmt = sdp_media_rformat(s->sdp, NULL);
 
 	s->pt_enc = fmt ? fmt->pt : -1;
@@ -644,7 +674,8 @@ void stream_update(struct stream *s)
 	if (sdp_media_has_media(s->sdp))
 		stream_remote_set(s);
 
-	if (s->menc && s->menc->mediah) {
+	if (s->mencs && mnat_ready(s)) {
+
 		err = start_mediaenc(s);
 		if (err) {
 			warning("stream: mediaenc update: %m\n", err);
@@ -941,6 +972,31 @@ int stream_jbuf_reset(struct stream *strm,
 }
 
 
+bool stream_is_ready(const struct stream *strm)
+{
+	if (!strm)
+		return false;
+
+	/* Media NAT */
+	if (strm->mnat) {
+		if (!mnat_ready(strm))
+			return false;
+	}
+
+	/* Media Enc */
+	if (strm->menc && strm->menc->wait_secure) {
+
+		if (!strm->menc_secure)
+			return false;
+	}
+
+	if (!sa_isset(&strm->raddr_rtp, SA_ALL))
+		return false;
+
+	return !strm->terminated;
+}
+
+
 void stream_set_secure(struct stream *strm, bool secure)
 {
 	if (!strm)
@@ -963,7 +1019,8 @@ int stream_start(const struct stream *strm)
 	if (!strm)
 		return EINVAL;
 
-	debug("stream: starting RTCP with remote %J\n", &strm->raddr_rtcp);
+	debug("stream: %s: starting RTCP with remote %J\n",
+			media_name(strm->type), &strm->raddr_rtcp);
 
 	rtcp_start(strm->rtp, strm->cname, &strm->raddr_rtcp);
 


### PR DESCRIPTION
This PR adds support for WebRTC interop.

The main change is that each stream layer is connected
in this order:

1. mnat (ICE)
2. menc (DTLS-SRTP)
3. audio/video media

Testing:

chrome 75.0.3770.100 and TRYITJsSIP -- ok
firefox 68.0 (64-bit) and TRYITJsSIP -- ok

Sample accounts:

```
"Anti Alf" <sip:alfredh2@sip.antisip.com>;outbound="sip:sip.antisip.com;transport=tcp";auth_pass=XXXX;regint=60;answermode=auto;medianat=ice;mediaenc=dtls_srtp
```

Sample config:

```
rtcp_mux                yes
module                  opus.so
module                  g711.so
module                  vp8.so
module                  ice.so
module                  dtls_srtp.so
```

