### PR TITLE
Avcodec hwaccel

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -230,35 +230,28 @@ static int module_init(void)
 		int ret;
 		int i;
 
-		info("avcodec: enable hwaccel using '%s'\n",
-		     hwaccel);
+		info("avcodec: enable hwaccel using '%s'\n", hwaccel);
 
 		type = av_hwdevice_find_type_by_name(hwaccel);
 		if (type == AV_HWDEVICE_TYPE_NONE) {
 
 			warning("avcodec: Device type"
-				" '%s' is not supported.\n",
-				hwaccel);
+				" '%s' is not supported.\n", hwaccel);
 
 			return ENOSYS;
 		}
-
-		info("AVHWDeviceType %d (%s)\n",
-		     type, av_hwdevice_get_type_name(type));
 
 		for (i = 0;; i++) {
 			const AVCodecHWConfig *config;
 
 			config = avcodec_get_hw_config(avcodec_h264dec, i);
 			if (!config) {
-				warning("Decoder %s does not"
+				warning("avcodec: Decoder %s does not"
 					" support device type %s.\n",
 					avcodec_h264dec->name,
 					av_hwdevice_get_type_name(type));
 				return ENOSYS;
 			}
-
-			info("hardware methods: 0x%x\n", config->methods);
 
 			if (config->methods
 			    & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -173,6 +173,10 @@ static int module_init(void)
 	char hwaccel[64];
 #endif
 
+#if 1
+	av_log_set_level(AV_LOG_VERBOSE);
+#endif
+
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
 	avcodec_init();
 #endif
@@ -250,6 +254,8 @@ static int module_init(void)
 					av_hwdevice_get_type_name(type));
 				return ENOSYS;
 			}
+
+			info("hardware methods: 0x%x\n", config->methods);
 
 			if (config->methods
 			    & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -176,10 +176,6 @@ static int module_init(void)
 	char hwaccel[64];
 #endif
 
-#if 1
-	av_log_set_level(AV_LOG_VERBOSE);
-#endif
-
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
 	avcodec_init();
 #endif

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -213,6 +213,7 @@ static int module_init(void)
 		     avcodec_h264dec->name, avcodec_h264dec->long_name);
 	}
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	/* common for encode/decode */
 	if (0 == conf_get_str(conf_cur(), "avcodec_hwaccel",
 			      hwaccel, sizeof(hwaccel))) {
@@ -269,6 +270,7 @@ static int module_init(void)
 			return ENOTSUP;
 		}
 	}
+#endif
 
 	return 0;
 }

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -6,6 +6,7 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#include <libavutil/pixdesc.h>
 #include <libavcodec/avcodec.h>
 #include "h26x.h"
 #include "avcodec.h"
@@ -41,6 +42,10 @@
 static const uint8_t h264_level_idc = 0x1f;
 AVCodec *avcodec_h264enc;             /* optional; specified H.264 encoder */
 AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
+
+
+AVBufferRef *hw_device_ctx = NULL;
+enum AVPixelFormat hw_pix_fmt;
 
 
 int avcodec_resolve_codecid(const char *s)
@@ -164,6 +169,8 @@ static int module_init(void)
 	struct list *vidcodecl = baresip_vidcodecl();
 	char h264enc[64] = "libx264";
 	char h264dec[64] = "h264";
+	char hwaccel[64];
+	int ret;
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
 	avcodec_init();
@@ -206,6 +213,63 @@ static int module_init(void)
 		     avcodec_h264dec->name, avcodec_h264dec->long_name);
 	}
 
+	/* common for encode/decode */
+	if (0 == conf_get_str(conf_cur(), "avcodec_hwaccel",
+			      hwaccel, sizeof(hwaccel))) {
+
+		enum AVHWDeviceType type;
+		int i;
+
+		info("avcodec: enable hwaccel using '%s'\n",
+		     hwaccel);
+
+		type = av_hwdevice_find_type_by_name(hwaccel);
+		if (type == AV_HWDEVICE_TYPE_NONE) {
+
+			warning("avcodec: Device type"
+				" '%s' is not supported.\n",
+				hwaccel);
+
+			return ENOSYS;
+		}
+
+		info("AVHWDeviceType %d (%s)\n",
+		     type, av_hwdevice_get_type_name(type));
+
+		for (i = 0;; i++) {
+			const AVCodecHWConfig *config;
+
+			config = avcodec_get_hw_config(avcodec_h264dec, i);
+			if (!config) {
+				warning("Decoder %s does not"
+					" support device type %s.\n",
+					avcodec_h264dec->name,
+					av_hwdevice_get_type_name(type));
+				return ENOSYS;
+			}
+
+			if (config->methods
+			    & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX
+			    &&
+			    config->device_type == type) {
+
+				hw_pix_fmt = config->pix_fmt;
+
+				info("avcodec: decode: using hardware"
+				     " pixel format '%s'\n",
+				     av_get_pix_fmt_name(config->pix_fmt));
+				break;
+			}
+		}
+
+		if ((ret = av_hwdevice_ctx_create(&hw_device_ctx, type,
+						  NULL, NULL, 0)) < 0) {
+			warning("avcodec: Failed to create HW device (%s)\n",
+				av_err2str(ret));
+			return ENOTSUP;
+		}
+	}
+
 	return 0;
 }
 
@@ -216,6 +280,8 @@ static int module_close(void)
 	vidcodec_unregister(&h263);
 	vidcodec_unregister(&h264);
 	vidcodec_unregister(&h264_1);
+
+	av_buffer_unref(&hw_device_ctx);
 
 	return 0;
 }

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -169,8 +169,9 @@ static int module_init(void)
 	struct list *vidcodecl = baresip_vidcodecl();
 	char h264enc[64] = "libx264";
 	char h264dec[64] = "h264";
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	char hwaccel[64];
-	int ret;
+#endif
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(53, 10, 0)
 	avcodec_init();
@@ -219,6 +220,7 @@ static int module_init(void)
 			      hwaccel, sizeof(hwaccel))) {
 
 		enum AVHWDeviceType type;
+		int ret;
 		int i;
 
 		info("avcodec: enable hwaccel using '%s'\n",

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -44,9 +44,11 @@ AVCodec *avcodec_h264enc;             /* optional; specified H.264 encoder */
 AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
 
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 AVBufferRef *hw_device_ctx = NULL;
 enum AVPixelFormat hw_pix_fmt;
 enum AVHWDeviceType hw_type = AV_HWDEVICE_TYPE_NONE;
+#endif
 
 
 int avcodec_resolve_codecid(const char *s)

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -45,9 +45,9 @@ AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
 
 
 #if LIBAVUTIL_VERSION_MAJOR >= 56
-AVBufferRef *hw_device_ctx = NULL;
-enum AVPixelFormat hw_pix_fmt;
-enum AVHWDeviceType hw_type = AV_HWDEVICE_TYPE_NONE;
+AVBufferRef *avcodec_hw_device_ctx = NULL;
+enum AVPixelFormat avcodec_hw_pix_fmt;
+enum AVHWDeviceType avcodec_hw_type = AV_HWDEVICE_TYPE_NONE;
 #endif
 
 
@@ -258,7 +258,7 @@ static int module_init(void)
 			    &&
 			    config->device_type == type) {
 
-				hw_pix_fmt = config->pix_fmt;
+				avcodec_hw_pix_fmt = config->pix_fmt;
 
 				info("avcodec: decode: using hardware"
 				     " pixel format '%s'\n",
@@ -267,14 +267,14 @@ static int module_init(void)
 			}
 		}
 
-		if ((ret = av_hwdevice_ctx_create(&hw_device_ctx, type,
+		if ((ret = av_hwdevice_ctx_create(&avcodec_hw_device_ctx, type,
 						  NULL, NULL, 0)) < 0) {
 			warning("avcodec: Failed to create HW device (%s)\n",
 				av_err2str(ret));
 			return ENOTSUP;
 		}
 
-		hw_type = type;
+		avcodec_hw_type = type;
 	}
 #endif
 
@@ -290,7 +290,8 @@ static int module_close(void)
 	vidcodec_unregister(&h264_1);
 
 #if LIBAVUTIL_VERSION_MAJOR >= 56
-	av_buffer_unref(&hw_device_ctx);
+	if (avcodec_hw_device_ctx)
+		av_buffer_unref(&avcodec_hw_device_ctx);
 #endif
 
 	return 0;

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -46,6 +46,7 @@ AVCodec *avcodec_h264dec;             /* optional; specified H.264 decoder */
 
 AVBufferRef *hw_device_ctx = NULL;
 enum AVPixelFormat hw_pix_fmt;
+enum AVHWDeviceType hw_type = AV_HWDEVICE_TYPE_NONE;
 
 
 int avcodec_resolve_codecid(const char *s)
@@ -277,6 +278,8 @@ static int module_init(void)
 				av_err2str(ret));
 			return ENOTSUP;
 		}
+
+		hw_type = type;
 	}
 #endif
 

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -296,7 +296,9 @@ static int module_close(void)
 	vidcodec_unregister(&h264);
 	vidcodec_unregister(&h264_1);
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	av_buffer_unref(&hw_device_ctx);
+#endif
 
 	return 0;
 }

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -35,6 +35,7 @@ extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
 extern AVBufferRef *hw_device_ctx;
 extern enum AVPixelFormat hw_pix_fmt;
+extern enum AVHWDeviceType hw_type;
 
 
 /*

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -33,9 +33,12 @@
 
 extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
+
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 extern AVBufferRef *hw_device_ctx;
 extern enum AVPixelFormat hw_pix_fmt;
 extern enum AVHWDeviceType hw_type;
+#endif
 
 
 /*

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -33,6 +33,8 @@
 
 extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
+extern AVBufferRef *hw_device_ctx;
+extern enum AVPixelFormat hw_pix_fmt;
 
 
 /*

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -35,9 +35,9 @@ extern AVCodec *avcodec_h264enc;
 extern AVCodec *avcodec_h264dec;
 
 #if LIBAVUTIL_VERSION_MAJOR >= 56
-extern AVBufferRef *hw_device_ctx;
-extern enum AVPixelFormat hw_pix_fmt;
-extern enum AVHWDeviceType hw_type;
+extern AVBufferRef *avcodec_hw_device_ctx;
+extern enum AVPixelFormat avcodec_hw_pix_fmt;
+extern enum AVHWDeviceType avcodec_hw_type;
 #endif
 
 

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -93,7 +93,7 @@ static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
 	const enum AVPixelFormat *p;
 
 	for (p = pix_fmts; *p != -1; p++) {
-		if (*p == hw_pix_fmt)
+		if (*p == avcodec_hw_pix_fmt)
 			return *p;
 	}
 
@@ -134,12 +134,12 @@ static int init_decoder(struct viddec_state *st, const char *name)
 
 #if LIBAVUTIL_VERSION_MAJOR >= 56
 	/* Hardware accelleration */
-	if (hw_device_ctx) {
-		st->ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+	if (avcodec_hw_device_ctx) {
+		st->ctx->hw_device_ctx = av_buffer_ref(avcodec_hw_device_ctx);
 		st->ctx->get_format = get_hw_format;
 
 		info("avcodec: decode: hardware accel enabled (%s)\n",
-		     av_hwdevice_get_type_name(hw_type));
+		     av_hwdevice_get_type_name(avcodec_hw_type));
 	}
 	else {
 		info("avcodec: decode: hardware accel disabled\n");

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -200,8 +200,13 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame)
 	int i, got_picture, ret;
 	int err = 0;
 
-	if (st->ctx->hw_device_ctx)
+#if LIBAVUTIL_VERSION_MAJOR >= 56
+	if (st->ctx->hw_device_ctx) {
 		hw_frame = av_frame_alloc();
+		if (!hw_frame)
+			return ENOMEM;
+	}
+#endif
 
 	err = mbuf_fill(st->mb, 0x00, AV_INPUT_BUFFER_PADDING_SIZE);
 	if (err)

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -138,7 +138,8 @@ static int init_decoder(struct viddec_state *st, const char *name)
 		st->ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
 		st->ctx->get_format = get_hw_format;
 
-		info("avcodec: decode: hardware accel enabled\n");
+		info("avcodec: decode: hardware accel enabled (%s)\n",
+		     av_hwdevice_get_type_name(hw_type));
 	}
 	else {
 		info("avcodec: decode: hardware accel disabled\n");

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -86,6 +86,7 @@ static inline void fragment_rewind(struct viddec_state *vds)
 }
 
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
                                         const enum AVPixelFormat *pix_fmts)
 {
@@ -99,6 +100,7 @@ static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
        fprintf(stderr, "Failed to get HW surface format.\n");
        return AV_PIX_FMT_NONE;
 }
+#endif
 
 
 static int init_decoder(struct viddec_state *st, const char *name)
@@ -129,17 +131,18 @@ static int init_decoder(struct viddec_state *st, const char *name)
 	if (!st->ctx || !st->pict)
 		return ENOMEM;
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	/* Hardware accelleration */
-       if (hw_device_ctx) {
-               st->ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
-               st->ctx->get_format = get_hw_format;
+	if (hw_device_ctx) {
+		st->ctx->hw_device_ctx = av_buffer_ref(hw_device_ctx);
+		st->ctx->get_format = get_hw_format;
 
-               info("avcodec: decode: hardware accel enabled\n");
-       }
-       else {
-               info("avcodec: decode: hardware accel disabled\n");
-       }
-
+		info("avcodec: decode: hardware accel enabled\n");
+	}
+	else {
+		info("avcodec: decode: hardware accel disabled\n");
+	}
+#endif
 
 	if (avcodec_open2(st->ctx, st->codec, NULL) < 0)
 		return ENOENT;
@@ -247,6 +250,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame)
 
 	if (got_picture) {
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 		if (hw_frame) {
 			/* retrieve data from GPU to CPU */
 			ret = av_hwframe_transfer_data(st->pict, hw_frame, 0);
@@ -256,6 +260,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame)
 				goto out;
 			}
 		}
+#endif
 
 		frame->fmt = avpixfmt_to_vidfmt(st->pict->format);
 		if (frame->fmt == (enum vidfmt)-1) {

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -90,15 +90,16 @@ static inline void fragment_rewind(struct viddec_state *vds)
 static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
                                         const enum AVPixelFormat *pix_fmts)
 {
-       const enum AVPixelFormat *p;
+	const enum AVPixelFormat *p;
 
-       for (p = pix_fmts; *p != -1; p++) {
-               if (*p == hw_pix_fmt)
-                       return *p;
-       }
+	for (p = pix_fmts; *p != -1; p++) {
+		if (*p == hw_pix_fmt)
+			return *p;
+	}
 
-       fprintf(stderr, "Failed to get HW surface format.\n");
-       return AV_PIX_FMT_NONE;
+	warning("avcodec: decode: Failed to get HW surface format.\n");
+
+	return AV_PIX_FMT_NONE;
 }
 #endif
 
@@ -260,8 +261,8 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame)
 			/* retrieve data from GPU to CPU */
 			ret = av_hwframe_transfer_data(st->pict, hw_frame, 0);
 			if (ret < 0) {
-				fprintf(stderr, "Error transferring the data"
-					" to system memory\n");
+				warning("avcodec: decode: Error transferring"
+					" the data to system memory\n");
 				goto out;
 			}
 		}

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -77,8 +77,9 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *device_ctx,
 	     width, height);
 
 	if (!(hw_frames_ref = av_hwframe_ctx_alloc(device_ctx))) {
-		fprintf(stderr, "Failed to create hardware frame context.\n");
-		return -1;
+		warning("avcodec: encode: Failed to create hardware"
+			" frame context.\n");
+		return ENOMEM;
 	}
 
 	frames_ctx = (AVHWFramesContext *)(void *)hw_frames_ref->data;
@@ -278,7 +279,8 @@ static int open_encoder(struct videnc_state *st,
 		if ((err = set_hwframe_ctx(st->ctx, hw_device_ctx,
 					   size->w, size->h)) < 0) {
 
-			fprintf(stderr, "Failed to set hwframe context.\n");
+			warning("avcodec: encode: Failed to set"
+				" hwframe context.\n");
 			goto out;
 		}
 	}
@@ -555,7 +557,8 @@ int avcodec_encode(struct videnc_state *st, bool update,
 
 		if ((err = av_hwframe_get_buffer(st->ctx->hw_frames_ctx,
 						 hw_frame, 0)) < 0) {
-			fprintf(stderr, "Error code: %s.\n", av_err2str(err));
+			warning("avcodec: encode: Error code: %s.\n",
+				av_err2str(err));
 			goto out;
 		}
 

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -515,9 +515,11 @@ int avcodec_encode(struct videnc_state *st, bool update,
 		goto out;
 	}
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	if (hw_type == AV_HWDEVICE_TYPE_VAAPI) {
 		hw_frame = av_frame_alloc();
 	}
+#endif
 
 	pict->format = hw_frame ? AV_PIX_FMT_NV12 : st->ctx->pix_fmt;
 	pict->width = frame->size.w;
@@ -540,7 +542,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 #endif
 
 #if LIBAVUTIL_VERSION_MAJOR >= 56
-	if ( hw_type == AV_HWDEVICE_TYPE_VAAPI ) {
+	if (hw_type == AV_HWDEVICE_TYPE_VAAPI) {
 
 		if ((err = av_hwframe_get_buffer(st->ctx->hw_frames_ctx,
 						 hw_frame, 0)) < 0) {

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -82,7 +82,7 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *device_ctx,
 	}
 	info("hw pix %s\n", av_get_pix_fmt_name(hw_pix_fmt));
 
-	frames_ctx = (AVHWFramesContext *)(hw_frames_ref->data);
+	frames_ctx = (AVHWFramesContext *)(void *)hw_frames_ref->data;
 	frames_ctx->format    = hw_pix_fmt;
 	frames_ctx->sw_format = AV_PIX_FMT_NV12;
 	frames_ctx->width     = width;
@@ -204,9 +204,12 @@ static int open_encoder(struct videnc_state *st,
 	st->ctx->bit_rate  = prm->bitrate;
 	st->ctx->width     = size->w;
 	st->ctx->height    = size->h;
+
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	if (hw_type == AV_HWDEVICE_TYPE_VAAPI)
 		st->ctx->pix_fmt   = hw_pix_fmt;
 	else
+#endif
 		st->ctx->pix_fmt   = pix_fmt;
 
 	st->ctx->time_base.num = 1;

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -65,6 +65,7 @@ static void destructor(void *arg)
 }
 
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *device_ctx,
 			   int width, int height)
 {
@@ -104,6 +105,7 @@ static int set_hwframe_ctx(AVCodecContext *ctx, AVBufferRef *device_ctx,
 
 	return err;
 }
+#endif
 
 
 static enum AVPixelFormat vidfmt_to_avpixfmt(enum vidfmt fmt)
@@ -255,6 +257,7 @@ static int open_encoder(struct videnc_state *st,
 		}
 	}
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	if (hw_device_ctx) {
 
 		/* set hw_frames_ctx for encoder's AVCodecContext */
@@ -266,6 +269,7 @@ static int open_encoder(struct videnc_state *st,
 			goto out;
 		}
 	}
+#endif
 
 	if (avcodec_open2(st->ctx, st->codec, NULL) < 0) {
 		err = ENOENT;
@@ -531,6 +535,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 	pict->color_range = AVCOL_RANGE_MPEG;
 #endif
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	if (hw_device_ctx) {
 
 		if ((err = av_hwframe_get_buffer(st->ctx->hw_frames_ctx,
@@ -553,6 +558,7 @@ int avcodec_encode(struct videnc_state *st, bool update,
 
 		av_frame_copy_props(hw_frame, pict);
 	}
+#endif
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 37, 100)
 


### PR DESCRIPTION
add support for hardware accelleration for ffmpeg decoder.

sample config:

```
avcodec_h264enc		h264_vaapi
avcodec_h264dec		h264
avcodec_hwaccel		vaapi
```

Testing:

* vaapi encoder
* vaapi decoder
* videotoolbox encoder
* videotoolbox decoder
