### PR TITLE
Use default PulseAudio device 

### DIFF
--- a/modules/pulse/player.c
+++ b/modules/pulse/player.c
@@ -81,7 +81,6 @@ int pulse_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 		       auplay_write_h *wh, void *arg)
 {
 	struct auplay_st *st;
-	struct mediadev *md;
 	pa_sample_spec ss;
 	pa_buffer_attr attr;
 	int err = 0, pa_error = 0;
@@ -119,12 +118,10 @@ int pulse_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	attr.minreq    = (uint32_t)-1;
 	attr.fragsize  = (uint32_t)-1;
 
-	md = mediadev_get_default(&ap->dev_list);
-
 	st->s = pa_simple_new(NULL,
 			      "Baresip",
 			      PA_STREAM_PLAYBACK,
-			      str_isset(device) ? device : md->name,
+			      str_isset(device) ? device : NULL,
 			      "VoIP Playback",
 			      &ss,
 			      NULL,

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -116,7 +116,6 @@ int pulse_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 			 ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
 {
 	struct ausrc_st *st;
-	struct mediadev *md;
 	pa_sample_spec ss;
 	pa_buffer_attr attr;
 	int pa_error;
@@ -160,12 +159,10 @@ int pulse_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	attr.minreq    = (uint32_t)-1;
 	attr.fragsize  = (uint32_t)pa_usec_to_bytes(prm->ptime * 1000, &ss);
 
-	md = mediadev_get_default(&as->dev_list);
-
 	st->s = pa_simple_new(NULL,
 			      "Baresip",
 			      PA_STREAM_RECORD,
-			      str_isset(device) ? device : md->name,
+			      str_isset(device) ? device : NULL,
 			      "VoIP Record",
 			      &ss,
 			      NULL,


### PR DESCRIPTION
Passing NULL to pa_simple_new as the device instructs PulseAudio to use the default. This is better then the current baresip behaviour which just uses the first device if no device was specified. In my case the first device was not the default.