### PR TITLE
menu: do not call cmd_answer if no current call

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -305,11 +305,15 @@ static int options_command(struct re_printf *pf, void *arg)
 static int cmd_answer(struct re_printf *pf, void *unused)
 {
 	struct ua *ua = uag_current();
+	struct call *call;
 	int err;
 	(void)unused;
 
-	if (!ua_call(ua))
-		return 0;
+	call = ua_call(ua);
+	if (!call || call_is_outgoing(call)) {
+		err = re_hprintf(pf, "no pending incoming calls to answer\n");
+		return err;
+	}
 
 	err = re_hprintf(pf, "%s: Answering incoming call\n", ua_aor(ua));
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -308,6 +308,9 @@ static int cmd_answer(struct re_printf *pf, void *unused)
 	int err;
 	(void)unused;
 
+	if (!ua_call(ua))
+		return 0;
+
 	err = re_hprintf(pf, "%s: Answering incoming call\n", ua_aor(ua));
 
 	/* Stop any ongoing ring-tones */


### PR DESCRIPTION
At the moment it is possible to spam cmd_answer command (by hitting `a`) if no active calls:
```
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
sip:8251@10.1.5.11: Answering incoming call
```

This patch fix this.