### PR TITLE
Account specific audio source and playback

### DIFF
--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -64,6 +64,7 @@ static int account_write_template(const char *file)
 			 "#    ;answermode={manual,early,auto}\n"
 			 "#    ;audio_codecs=opus/48000/2,pcma,...\n"
 			 "#    ;audio_source=alsa,default\n"
+			 "#    ;audio_player=alsa,default\n"
 			 "#    ;auth_user=username\n"
 			 "#    ;auth_pass=password\n"
 			 "#    ;call_transfer=no\n"

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -63,6 +63,7 @@ static int account_write_template(const char *file)
 			 "#  addr-params:\n"
 			 "#    ;answermode={manual,early,auto}\n"
 			 "#    ;audio_codecs=opus/48000/2,pcma,...\n"
+			 "#    ;audio_source=alsa,default\n"
 			 "#    ;auth_user=username\n"
 			 "#    ;auth_pass=password\n"
 			 "#    ;call_transfer=no\n"

--- a/src/account.c
+++ b/src/account.c
@@ -37,6 +37,8 @@ static void destructor(void *arg)
 	mem_deref(acc->buf);
 	mem_deref(acc->ausrc_mod);
 	mem_deref(acc->ausrc_dev);
+	mem_deref(acc->auplay_mod);
+	mem_deref(acc->auplay_dev);
 }
 
 
@@ -421,10 +423,12 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	if (err)
 		goto out;
 
-	err = decode_pair(&acc->ausrc_mod, &acc->ausrc_dev,
-			  &acc->laddr.params, "audio_source");
+	err  = decode_pair(&acc->ausrc_mod, &acc->ausrc_dev,
+			   &acc->laddr.params, "audio_source");
+	err |= decode_pair(&acc->auplay_mod, &acc->auplay_dev,
+			   &acc->laddr.params, "audio_player");
 	if (err) {
-		warning("account: audio_source parse error\n");
+		warning("account: audio_source/player parse error\n");
 		goto out;
 	}
 

--- a/src/account.c
+++ b/src/account.c
@@ -144,7 +144,7 @@ static int media_decode(struct account *acc, const struct pl *prm)
 
 
 static int decode_pair(char **val1, char **val2,
-		       const char *name, const struct pl *params)
+		       const struct pl *params, const char *name)
 {
 	struct pl val, pl1, pl2;
 	int err = 0;
@@ -422,7 +422,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 		goto out;
 
 	err = decode_pair(&acc->ausrc_mod, &acc->ausrc_dev,
-			  "audio_source", &acc->laddr.params);
+			  &acc->laddr.params, "audio_source");
 	if (err) {
 		warning("account: audio_source parse error\n");
 		goto out;

--- a/src/account.c
+++ b/src/account.c
@@ -1209,10 +1209,5 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 	err |= re_hprintf(pf, " call_transfer:         %s\n",
 			  account_call_transfer(acc));
 
-	if (acc->ausrc_mod) {
-		err |= re_hprintf(pf, " audio_source: %s,%s\n",
-				  acc->ausrc_mod, acc->ausrc_dev);
-	}
-
 	return err;
 }

--- a/src/core.h
+++ b/src/core.h
@@ -76,6 +76,8 @@ struct account {
 	struct list vidcodecl;       /**< List of preferred video-codecs     */
 	bool mwi;                    /**< MWI on/off                         */
 	bool refer;                  /**< REFER method on/off                */
+	char *ausrc_mod;
+	char *ausrc_dev;
 };
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -78,6 +78,8 @@ struct account {
 	bool refer;                  /**< REFER method on/off                */
 	char *ausrc_mod;
 	char *ausrc_dev;
+	char *auplay_mod;
+	char *auplay_dev;
 };
 
 

--- a/test/account.c
+++ b/test/account.c
@@ -29,6 +29,7 @@ static const char str[] =
 	";stunserver=\"stun:stunserver.org\""
 	";mwi=no"
 	";call_transfer=no"
+	";audio_source=null,null"
 	;
 
 


### PR DESCRIPTION
Add support for specifying audio source and player per account.
The global config will be used by default.

Syntax:

```
;audio_source="module,device"
;audio_player="module,device"
```

Example with multiple accounts/devices:

```
<sip:user1@example.com>;audio_source=alsa,plughw:0,1
<sip:user2@example.com>;audio_source=alsa,plughw:0,2
<sip:user3@example.com>;audio_source=alsa,plughw:0,3
```

Please review and test.