### PR TITLE
ua: add support for SIP trace

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -745,6 +745,7 @@ int  ua_init(const char *software, bool udp, bool tcp, bool tls);
 void ua_close(void);
 void ua_stop_all(bool forced);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
+void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);
 int  uag_event_register(ua_event_h *eh, void *arg);
 void uag_event_unregister(ua_event_h *eh);

--- a/src/main.c
+++ b/src/main.c
@@ -59,11 +59,11 @@ static void usage(void)
 			 "\t-m <module>      Pre-load modules (repeat)\n"
 			 "\t-p <path>        Audio files\n"
 			 "\t-h -?            Help\n"
+			 "\t-s               Enable SIP trace\n"
 			 "\t-t               Test and exit\n"
 			 "\t-n <net_if>      Specify network interface\n"
 			 "\t-u <parameters>  Extra UA parameters\n"
 			 "\t-v               Verbose debug\n"
-			 "\t-i               Include SIP trace in output\n"
 			 );
 }
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 
 #ifdef HAVE_GETOPT
 	for (;;) {
-		const int c = getopt(argc, argv, "46de:f:p:hu:n:vtm:i");
+		const int c = getopt(argc, argv, "46de:f:p:hu:n:vstm:");
 		if (0 > c)
 			break;
 
@@ -153,6 +153,10 @@ int main(int argc, char *argv[])
 			audio_path = optarg;
 			break;
 
+		case 's':
+			sip_trace = true;
+			break;
+
 		case 't':
 			test = true;
 			break;
@@ -167,10 +171,6 @@ int main(int argc, char *argv[])
 
 		case 'v':
 			log_enable_debug(true);
-			break;
-
-		case 'i':
-			sip_trace = true;
 			break;
 
 		default:

--- a/src/main.c
+++ b/src/main.c
@@ -63,6 +63,7 @@ static void usage(void)
 			 "\t-n <net_if>      Specify network interface\n"
 			 "\t-u <parameters>  Extra UA parameters\n"
 			 "\t-v               Verbose debug\n"
+			 "\t-i               Include SIP trace in output\n"
 			 );
 }
 
@@ -75,6 +76,7 @@ int main(int argc, char *argv[])
 	const char *net_interface = NULL;
 	const char *audio_path = NULL;
 	const char *modv[16];
+	bool sip_trace = false;
 	size_t execmdc = 0;
 	size_t modc = 0;
 	size_t i;
@@ -98,7 +100,7 @@ int main(int argc, char *argv[])
 
 #ifdef HAVE_GETOPT
 	for (;;) {
-		const int c = getopt(argc, argv, "46de:f:p:hu:n:vtm:");
+		const int c = getopt(argc, argv, "46de:f:p:hu:n:vtm:i");
 		if (0 > c)
 			break;
 
@@ -165,6 +167,10 @@ int main(int argc, char *argv[])
 
 		case 'v':
 			log_enable_debug(true);
+			break;
+
+		case 'i':
+			sip_trace = true;
 			break;
 
 		default:
@@ -247,6 +253,9 @@ int main(int argc, char *argv[])
 		if (err)
 			goto out;
 	}
+
+	if (sip_trace)
+		uag_enable_sip_trace(true);
 
 	if (test)
 		goto out;

--- a/src/ua.c
+++ b/src/ua.c
@@ -1495,6 +1495,24 @@ static bool sub_handler(const struct sip_msg *msg, void *arg)
 }
 
 
+#ifdef LIBRE_HAVE_SIPTRACE
+static void sip_trace_handler(bool tx, enum sip_transp tp,
+			      const struct sa *src, const struct sa *dst,
+			      const uint8_t *pkt, size_t len, void *arg)
+{
+	(void)arg;
+
+	re_printf("\x1b[36;1m"
+		  "#\n"
+		  "%s %J -> %J\n"
+		  "%b"
+		  "\x1b[;m\n"
+		  ,
+		  sip_transp_name(tp), src, dst, pkt, len);
+}
+#endif
+
+
 /**
  * Initialise the User-Agents
  *
@@ -1630,6 +1648,16 @@ void uag_set_exit_handler(ua_exit_h *exith, void *arg)
 {
 	uag.exith = exith;
 	uag.arg = arg;
+}
+
+
+void uag_enable_sip_trace(bool enable)
+{
+#ifdef LIBRE_HAVE_SIPTRACE
+	sip_set_trace_handler(uag.sip, enable ? sip_trace_handler : NULL);
+#else
+	warning("no sip trace in libre\n");
+#endif
 }
 
 


### PR DESCRIPTION
this requires a special version of libre:

  https://github.com/alfredh/re

To run baresip with SIP trace enabled:

```
$ baresip -i
```

(the letter `i` is open to better ideas).
