### PR TITLE
Fix osx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ LIBRE_MK  := $(shell [ -f /usr/local/share/re/re.mk ] && \
 endif
 endif
 
+
+ifeq ($(SYSROOT_LOCAL),)
+SYSROOT_LOCAL := $(shell [ -d /usr/local/include ] && echo "/usr/local")
+endif
+
+
 include $(LIBRE_MK)
 include mk/modules.mk
 
@@ -44,14 +50,25 @@ endif
 
 
 CFLAGS    += -I. -Iinclude -I$(LIBRE_INC)
+ifneq ($(LIBREM_PATH),)
 CFLAGS    += -I$(LIBREM_PATH)/include
+endif
 CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
-CFLAGS    += -I/usr/local/include/rem
+ifneq ($(SYSROOT_LOCAL),)
+CFLAGS    += -I$(SYSROOT_LOCAL)/include/rem
+endif
+
 
 CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
+ifneq ($(LIBREM_PATH),)
 CXXFLAGS  += -I$(LIBREM_PATH)/include
+endif
 CXXFLAGS  += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
+ifneq ($(SYSROOT_LOCAL),)
+CXXFLAGS  += -I$(SYSROOT_LOCAL)/include/rem
+endif
 CXXFLAGS  += $(EXTRA_CXXFLAGS)
+
 
 # XXX: common for C/C++
 CPPFLAGS += -DHAVE_INTTYPES_H

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,10 @@ LIBREM_PATH	:= $(shell [ -d ../rem ] && echo "../rem")
 endif
 
 
-CFLAGS    += -I. -Iinclude -I$(LIBRE_INC) -I$(SYSROOT)/include
+CFLAGS    += -I. -Iinclude -I$(LIBRE_INC)
 CFLAGS    += -I$(LIBREM_PATH)/include
 CFLAGS    += -I$(SYSROOT)/local/include/rem -I$(SYSROOT)/include/rem
+CFLAGS    += -I/usr/local/include/rem
 
 CXXFLAGS  += -I. -Iinclude -I$(LIBRE_INC)
 CXXFLAGS  += -I$(LIBREM_PATH)/include
@@ -134,12 +135,12 @@ endif
 ifneq ($(STATIC),)
 LIBS      += $(MOD_LFLAGS)
 else
-LIBS      += -L$(SYSROOT)/local/lib
-MOD_LFLAGS += -L$(SYSROOT)/local/lib
+#LIBS      += -L$(SYSROOT)/local/lib
+#MOD_LFLAGS += -L$(SYSROOT)/local/lib
 endif
 
 LIBS      += -lrem -lm
-LIBS      += -L$(SYSROOT)/lib
+#LIBS      += -L$(SYSROOT)/lib
 
 ifeq ($(OS),win32)
 TEST_LIBS += -static-libgcc

--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,12 @@ endif
 ifneq ($(STATIC),)
 LIBS      += $(MOD_LFLAGS)
 else
-#LIBS      += -L$(SYSROOT)/local/lib
-#MOD_LFLAGS += -L$(SYSROOT)/local/lib
+
+ifneq ($(SYSROOT_LOCAL),)
+LIBS      += -L$(SYSROOT_LOCAL)/lib
+MOD_LFLAGS += -L$(SYSROOT_LOCAL)/lib
+endif
+
 endif
 
 LIBS      += -lrem -lm


### PR DESCRIPTION
after this commit in libre:

https://github.com/creytiv/re/commit/18ba584f02a525e066de4e9eb24d9f36a4c49ae2

the `SYSROOT` variable now points to the OSX SDK selected by xcode-select:

```
  SYSROOT:       /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr
```

compiling baresip on OSX now gives thousands of warnings
from the system header files.

The compile should have a list of include paths for system header
files, so there is no need for us to explicitly specify it.

```
clang -x c -v -E /dev/null
Apple LLVM version 9.0.0 (clang-900.0.39.2)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" -cc1 -triple x86_64-apple-macosx10.12.0 -Wdeprecated-objc-isa-usage -Werror=deprecated-objc-isa-usage -E -disable-free -disable-llvm-verifier -discard-value-names -main-file-name null -mrelocation-model pic -pic-level 2 -mthread-model posix -mdisable-fp-elim -fno-strict-return -masm-verbose -munwind-tables -target-cpu penryn -target-linker-version 305 -v -dwarf-column-info -debugger-tuning=lldb -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0 -fdebug-compilation-dir /Users/alfredh/tmp/baresip -ferror-limit 19 -fmessage-length 120 -stack-protector 1 -fblocks -fobjc-runtime=macosx-10.12.0 -fencode-extended-block-signature -fmax-type-align=16 -fdiagnostics-show-option -fcolor-diagnostics -o - -x c /dev/null
clang -cc1 version 9.0.0 (clang-900.0.39.2) default target x86_64-apple-darwin16.7.0
#include "..." search starts here:
#include <...> search starts here:
 /usr/local/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.0.0/include
 /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include
 /usr/include
 /System/Library/Frameworks (framework directory)
 /Library/Frameworks (framework directory)
End of search list.
# 1 "/dev/null"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 331 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "/dev/null" 2
```

This patch has been tested on the following platforms:

* Debian 10
* OSX 10.12
* iOS SDK
* Android NDK
* OpenBSD 6.5

please test if it works on your system. merging to master will
happen soon, unless I hear any complaints.
