### PR TITLE
avcodec: use AVFrame key_frame flag to check for keyframes

### DIFF
--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -270,16 +270,6 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 		}
 #endif
 
-		if (st->pict->key_frame) {
-
-			re_printf(">>> KEYFRAME <<<\n");
-
-			*intra = true;
-			st->got_keyframe = true;
-			++st->stats.n_key;
-		}
-
-
 		frame->fmt = avpixfmt_to_vidfmt(st->pict->format);
 		if (frame->fmt == (enum vidfmt)-1) {
 			warning("avcodec: decode: bad pixel format"
@@ -295,6 +285,13 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 		}
 		frame->size.w = st->ctx->width;
 		frame->size.h = st->ctx->height;
+
+		if (st->pict->key_frame) {
+
+			*intra = true;
+			st->got_keyframe = true;
+			++st->stats.n_key;
+		}
 	}
 
  out:


### PR DESCRIPTION
instead of manually parsing the video packets, we use the libavcodec decoder
to determine if a frame is a keyframe. this results in much simpler code.

testing:

```
Debian 8	libav 11.12		ok
Debian 9	ffmpeg 3.2.14-1		ok
OSX 10.12	ffmpeg 4.2.1		ok
OpenBSD 6.5	ffmpeg 4.1.3		ok
```
