### PR TITLE
MPA layer 3 encoding fixes

### DIFF
--- a/modules/mpa/encode.c
+++ b/modules/mpa/encode.c
@@ -79,8 +79,8 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	aes->channels = ac->ch;
 
 	prm.samplerate = 48000;
-	prm.bitrate    = 128000;
-	prm.layer      = 2;
+	prm.bitrate    = 64000;
+	prm.layer      = 3;
 	prm.mode       = MONO;
 	mpa_decode_fmtp(&prm, fmtp);
 	aes->samplerate = prm.samplerate;
@@ -92,6 +92,10 @@ int mpa_encode_update(struct auenc_state **aesp, const struct aucodec *ac,
 	result |= lame_set_in_samplerate(aes->enc, prm.samplerate);
 	result |= lame_set_out_samplerate(aes->enc, prm.samplerate);
 	result |= lame_set_num_channels(aes->enc, 2);
+	result |= lame_set_VBR(aes->enc, vbr_off);
+	result |= lame_set_bWriteVbrTag(aes->enc, 0);
+	result |= lame_set_strict_ISO(aes->enc, 1);
+	result |= lame_set_disable_reservoir(aes->enc, 1);
 	if (result!=0) {
 		warning("MPA enc set failed\n");
 		err=EINVAL;

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -139,15 +139,11 @@ static int module_init(void)
 
 	strcpy(mode,mpa.fmtp);
 
-	if (0 == conf_get_u32(conf, "mpa_layer", &value)) {
-		if (value<1 || value>4) {
-			warning("MPA layer 1, 2 or 3 are allowed.");
-			return EINVAL;
-		}
-		(void)re_snprintf(fmtp+strlen(fmtp),
-			sizeof(fmtp)-strlen(fmtp),
-			";layer=%d", value);
-	}
+	/* advertise layer 3 encoding only */
+	(void)re_snprintf(fmtp+strlen(fmtp),
+		sizeof(fmtp)-strlen(fmtp),
+		"layer=%d", 3);
+
 	if (0 == conf_get_u32(conf, "mpa_samplerate", &value)) {
 
 		switch (value) {

--- a/modules/mpa/mpa.c
+++ b/modules/mpa/mpa.c
@@ -109,7 +109,7 @@ static struct aucodec mpa = {
 	.ch        = 2,
 	.pch       = 1,
 /* MPA does not expect channels count, even those it is stereo */
-	.fmtp      = "layer=2",
+	.fmtp      = "layer=3",
 	.encupdh   = mpa_encode_update,
 	.ench      = mpa_encode_frm,
 	.decupdh   = mpa_decode_update,

--- a/modules/mpa/sdp.c
+++ b/modules/mpa/sdp.c
@@ -39,7 +39,7 @@ void mpa_decode_fmtp(struct mpa_param *prm, const char *fmtp)
 		assign_if (&prm->samplerate, &val, 32000, 48000);
 
 	if (fmt_param_get(&pl, "layer", &val))
-		assign_if (&prm->layer, &val, 1, 3);
+		assign_if (&prm->layer, &val, 3, 3);
 
 	if (fmt_param_get(&pl, "mode", &val)) {
 

--- a/modules/mpa/sdp.c
+++ b/modules/mpa/sdp.c
@@ -33,10 +33,10 @@ void mpa_decode_fmtp(struct mpa_param *prm, const char *fmtp)
 	pl_set_str(&pl, fmtp);
 
 	if (fmt_param_get(&pl, "bitrate", &val))
-		assign_if (&prm->bitrate, &val, 8000, 384000);
+		assign_if (&prm->bitrate, &val, 32000, 320000);
 
 	if (fmt_param_get(&pl, "samplerate", &val))
-		assign_if (&prm->samplerate, &val, 16000, 48000);
+		assign_if (&prm->samplerate, &val, 32000, 48000);
 
 	if (fmt_param_get(&pl, "layer", &val))
 		assign_if (&prm->layer, &val, 1, 3);
@@ -47,10 +47,10 @@ void mpa_decode_fmtp(struct mpa_param *prm, const char *fmtp)
 			prm->mode = STEREO;
 		else if (!strncmp("joint_stereo",val.p,val.l))
 			prm->mode = JOINT_STEREO;
-		else if (!strncmp("single_channel",val.p,val.l))
-			prm->mode = MONO;
 		else if (!strncmp("dual_channel",val.p,val.l))
 			prm->mode = DUAL_CHANNEL;
+		else if (!strncmp("single_channel",val.p,val.l))
+			prm->mode = MONO;
 	}
 }
 


### PR DESCRIPTION
Please note: The MPA module currently does layer 3 encoding only (using `libmp3lame`).
It tries to advertise this by SDP and apply constraints even to mirrored fmtp encoding.

There are not any constraints decoding other audio layers.

Encoding layer 2 (MP2) would require dynamic switching to `libtwolame` encoding which is not implemented (yet).