### PR TITLE
aui2s: add rtos i2s audio driver module

### DIFF
--- a/modules/i2s/i2s.c
+++ b/modules/i2s/i2s.c
@@ -1,0 +1,113 @@
+/**
+ * @file i2s freeRTOS I2S audio driver module
+ *
+ * Copyright (C) 2019 cspiel.at
+ */
+#include <sys/types.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "freertos/FreeRTOS.h"
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+
+#include "driver/i2s.h"
+#include "i2s.h"
+
+
+static struct ausrc *ausrc = NULL;
+static struct auplay *auplay = NULL;
+static enum I2SOnMask _i2s_on = I2O_NONE;
+
+/*---------------------------------------------------------------
+                            CONFIG
+---------------------------------------------------------------*/
+
+static int i2s_init(void)
+{
+	int err;
+
+	err  = ausrc_register(&ausrc, baresip_ausrcl(),
+			      "i2s", i2s_src_alloc);
+	err |= auplay_register(&auplay, baresip_auplayl(),
+			       "i2s", i2s_play_alloc);
+
+
+	return err;
+}
+
+
+int i2s_start_bus(uint32_t srate, enum I2SOnMask playrec, uint8_t channels)
+{
+	esp_err_t err;
+	bool start = _i2s_on == I2O_NONE;
+	_i2s_on = _i2s_on | playrec;
+
+	if (srate * 4 % DMA_SIZE) {
+		warning("i2s: srate*4 % DMA_SIZE != 0\n");
+		return EINVAL;
+	}
+
+	info("%s start with _i2s_on=%d", __func__, _i2s_on);
+	if (start) {
+		i2s_config_t i2s_config = {
+			.mode = I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_TX,
+			.sample_rate =  srate,
+			.bits_per_sample = 32,
+			.communication_format = I2S_COMM_FORMAT_I2S |
+				I2S_COMM_FORMAT_I2S_MSB,
+			.channel_format = channels ? I2S_CHANNEL_FMT_ONLY_RIGHT
+			    : I2S_CHANNEL_FMT_RIGHT_LEFT,
+			.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,
+			.dma_buf_count = 2,
+			.dma_buf_len = DMA_SIZE,
+			.use_apll = 0                       /* disables APLL */
+		};
+
+		/* install and start i2s driver */
+		err = i2s_driver_install(I2S_PORT, &i2s_config, 0, NULL);
+		if (err) {
+			warning("i2s: could not install i2s driver (%s)",
+					esp_err_to_name(err));
+			return EINVAL;
+		}
+		i2s_pin_config_t pins = {
+			.bck_io_num = 26,
+			.ws_io_num = 25,
+			.data_out_num = 22,
+			.data_in_num = 23
+		};
+		i2s_set_pin(I2S_PORT, &pins);
+
+		i2s_zero_dma_buffer(I2S_PORT);
+	}
+
+	return 0;
+}
+
+
+void i2s_stop_bus(enum I2SOnMask playrec)
+{
+	_i2s_on &= (~playrec);
+
+	info("%s _i2s_on=%d", __func__, _i2s_on);
+	if (_i2s_on == I2O_NONE)
+		i2s_driver_uninstall(I2S_PORT);
+}
+
+
+static int i2s_close(void)
+{
+	ausrc  = mem_deref(ausrc);
+	auplay = mem_deref(auplay);
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(i2s) = {
+	"i2s",
+	"sound",
+	i2s_init,
+	i2s_close
+};

--- a/modules/i2s/i2s.h
+++ b/modules/i2s/i2s.h
@@ -1,0 +1,33 @@
+/**
+ * @file i2s.h freeRTOS I2S audio driver module - internal interface
+ *
+ * Copyright (C) 2019 cspiel.at
+ */
+
+#define I2S_PORT           (0)
+#define DMA_SIZE           (640)
+
+enum I2SOnMask {
+	I2O_NONE = 0,
+	I2O_PLAY = 1,
+	I2O_RECO = 2,
+	I2O_BOTH = 3
+};
+
+
+int i2s_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
+			     struct media_ctx **ctx,
+			     struct ausrc_prm *prm, const char *device,
+			     ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
+
+
+int i2s_play_alloc(struct auplay_st **stp, const struct auplay *ap,
+		    struct auplay_prm *prm, const char *device,
+		    auplay_write_h *wh, void *arg);
+
+
+int i2s_start_bus(uint32_t srate, enum I2SOnMask playrec, uint8_t channels);
+
+
+void i2s_stop_bus(enum I2SOnMask playrec);
+

--- a/modules/i2s/i2s_play.c
+++ b/modules/i2s/i2s_play.c
@@ -1,0 +1,161 @@
+/**
+ * @file i2s_play.c freeRTOS I2S audio driver module - player
+ *
+ * Copyright (C) 2019 cspiel.at
+ */
+#include <sys/types.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "freertos/FreeRTOS.h"
+#include "driver/i2s.h"
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include "i2s.h"
+
+
+struct auplay_st {
+	const struct auplay *ap;  /* pointer to base-class (inheritance) */
+	pthread_t thread;
+	bool run;
+	void *sampv;
+	size_t sampc;
+	auplay_write_h *wh;
+	void *arg;
+	struct auplay_prm prm;
+
+	uint32_t *pcm;
+};
+
+
+static void auplay_destructor(void *arg)
+{
+	struct auplay_st *st = arg;
+
+	/* Wait for termination of other thread */
+	if (st->run) {
+		info("i2s: stopping playback thread\n");
+		st->run = false;
+		(void)pthread_join(st->thread, NULL);
+	}
+
+	mem_deref(st->sampv);
+	mem_deref(st->pcm);
+}
+
+
+/**
+ * Converts samples from int16_t to pcm 32 bit values ready for I2S bus. A
+ * reasonable volume of the playback is achieved by left-shifting.
+ * @param st The auplay_st.
+ * @param i  Offset for st->sampv.
+ * @param n  Number of samples that should be converted.
+ */
+static void convert_sampv(struct auplay_st *st, size_t i, size_t n)
+{
+	uint32_t j;
+	int16_t *sampv = st->sampv;
+	for (j = 0; j < n; j++) {
+		uint32_t v = sampv[i+j];
+		st->pcm[j] = v << 17;
+	}
+}
+
+static void *write_thread(void *arg)
+{
+	struct auplay_st *st = arg;
+
+	i2s_set_clk(I2S_PORT, st->prm.srate, 32, st->prm.ch);
+	while (st->run) {
+		size_t i;
+
+		st->wh(st->sampv, st->sampc, st->arg);
+		for (i = 0; i + DMA_SIZE / 4 <= st->sampc;) {
+			size_t n;
+			convert_sampv(st, i, DMA_SIZE / 4);
+
+			if (i2s_write(I2S_PORT, (const uint8_t*) st->pcm,
+					DMA_SIZE, &n, portMAX_DELAY) != ESP_OK)
+				break;
+
+			if (n != DMA_SIZE)
+				warning("i2s: written %lu bytes but expected"
+					" %lu.", n, DMA_SIZE);
+
+			if (n == 0)
+				break;
+
+			i += (n / 4);
+		}
+	}
+
+	i2s_stop_bus(I2O_PLAY);
+	info("i2s: stopped auplay thread\n");
+
+	return NULL;
+}
+
+
+int i2s_play_alloc(struct auplay_st **stp, const struct auplay *ap,
+		    struct auplay_prm *prm, const char *device,
+		    auplay_write_h *wh, void *arg)
+{
+	struct auplay_st *st;
+	int err;
+
+	(void) device;
+
+	if (!stp || !ap || !prm || !wh)
+		return EINVAL;
+
+	if (prm->fmt!=AUFMT_S16LE) {
+		warning("i2s: unsupported sample format %s\n",
+			aufmt_name(prm->fmt));
+		return EINVAL;
+	}
+
+	st = mem_zalloc(sizeof(*st), auplay_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->prm = *prm;
+	st->ap  = ap;
+	st->wh  = wh;
+	st->arg = arg;
+
+	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
+	st->sampv = mem_zalloc(aufmt_sample_size(st->prm.fmt)*st->sampc, NULL);
+	if (!st->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+	st->pcm = mem_zalloc(DMA_SIZE, NULL);
+	if (!st->pcm) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	err = i2s_start_bus(st->prm.srate, I2O_PLAY, st->prm.ch);
+	if (err)
+		goto out;
+
+	st->run = true;
+	info("%s starting play thread\n", __func__);
+	err = pthread_create(&st->thread, NULL, write_thread, st);
+	if (err) {
+		st->run = false;
+		goto out;
+	}
+
+	debug("i2s: playback started\n");
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}

--- a/modules/i2s/i2s_src.c
+++ b/modules/i2s/i2s_src.c
@@ -1,0 +1,172 @@
+/**
+ * @file i2s_src.c freeRTOS I2S audio driver module - recorder
+ *
+ * Copyright (C) 2019 cspiel.at
+ */
+#include <sys/types.h>
+#include <sys/time.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include "freertos/FreeRTOS.h"
+#include "driver/i2s.h"
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include "i2s.h"
+
+
+struct ausrc_st {
+	const struct ausrc *as;  /* pointer to base-class (inheritance) */
+	pthread_t thread;
+	bool run;
+	void *sampv;
+	size_t sampc;
+	ausrc_read_h *rh;
+	void *arg;
+	struct ausrc_prm prm;
+
+	uint32_t *pcm;
+};
+
+
+static void ausrc_destructor(void *arg)
+{
+	struct ausrc_st *st = arg;
+
+	/* Wait for termination of other thread */
+	if (st->run) {
+		info("i2s: stopping recording thread\n");
+		st->run = false;
+		(void)pthread_join(st->thread, NULL);
+	}
+
+	mem_deref(st->sampv);
+	mem_deref(st->pcm);
+}
+
+
+/**
+ * Converts the pcm 32 bit I2S values to baresip 16-bit samples. A reasonable
+ * volume for the microphone is achieved by right shifting.
+ * @param st The ausrc_st.
+ * @param i  Offset for st->sampv.
+ * @param n  The number of samples that should be converted.
+ */
+static void convert_pcm(struct ausrc_st *st, size_t i, size_t n)
+{
+	uint32_t j;
+	uint16_t *sampv = st->sampv;
+	for (j = 0; j < n; j++) {
+		uint32_t v = st->pcm[j];
+		uint16_t *o = sampv + i + j;
+		*o = v >> 15;
+		/* if negative fill with ff */
+		if (v & 0x80000000)
+			*o |= 0xfffe0000;
+	}
+}
+
+
+static void *read_thread(void *arg)
+{
+	struct ausrc_st *st = arg;
+
+	while (st->run) {
+		size_t i;
+
+		for (i = 0; i + DMA_SIZE / 4 <= st->sampc;) {
+			size_t n = 0;
+			if (i2s_read(I2S_PORT, st->pcm, DMA_SIZE, &n,
+						portMAX_DELAY) != ESP_OK)
+				break;
+
+			if (n == 0)
+				break;
+
+			convert_pcm(st, i, n / 4);
+			i += (n / 4);
+		}
+
+		st->rh(st->sampv, st->sampc, st->arg);
+	}
+
+	i2s_stop_bus(I2O_RECO);
+	info("i2s: stopped ausrc thread\n");
+
+	return NULL;
+}
+
+
+int i2s_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
+			     struct media_ctx **ctx,
+			     struct ausrc_prm *prm, const char *device,
+			     ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
+{
+	struct ausrc_st *st;
+	size_t sampc;
+	int err;
+
+	(void) ctx;
+	(void) device;
+	(void) errh;
+
+	if (!stp || !as || !prm || !rh)
+		return EINVAL;
+
+	if (prm->fmt!=AUFMT_S16LE) {
+		warning("i2s: unsupported sample format %s\n",
+				aufmt_name(prm->fmt));
+		return EINVAL;
+	}
+
+	sampc = prm->srate * prm->ch * prm->ptime / 1000;
+	if (sampc % (DMA_SIZE / 4)) {
+		warning("i2s: sampc=%d has to be divisible by DMA_SIZE/4\n",
+				sampc);
+		return EINVAL;
+	}
+
+	st = mem_zalloc(sizeof(*st), ausrc_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->prm = *prm;
+	st->as  = as;
+	st->rh  = rh;
+	st->arg = arg;
+
+	st->sampc = sampc;
+	st->sampv = mem_zalloc(aufmt_sample_size(st->prm.fmt)*st->sampc, NULL);
+	if (!st->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+	st->pcm = mem_zalloc(DMA_SIZE, NULL);
+	if (!st->pcm) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	err = i2s_start_bus(st->prm.srate, I2O_RECO, st->prm.ch);
+	if (err)
+		goto out;
+
+	st->run = true;
+	info("%s starting src thread\n", __func__);
+	err = pthread_create(&st->thread, NULL, read_thread, st);
+	if (err) {
+		st->run = false;
+		goto out;
+	}
+
+	debug("i2s: recording\n");
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}

--- a/modules/i2s/module.mk
+++ b/modules/i2s/module.mk
@@ -1,0 +1,10 @@
+#
+# module.mk
+#
+# Copyright (C) 2019 cspiel.at
+#
+
+MOD		:= i2s
+$(MOD)_SRCS	+= i2s.c
+
+include mk/mod.mk


### PR DESCRIPTION
An I2S audio driver for freeRTOS.

Tested with:
MAX98357A - i2S CLASS D stereo amplifier
Sparkfun I2S Audio Breakout - MAX98357A SF14809