### PR TITLE
audio: add ptime to struct aucodec

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -986,6 +986,7 @@ struct aucodec {
 	uint32_t crate;             /* RTP Clock rate   */
 	uint8_t ch;
 	uint8_t pch;                /* RTP packet channels */
+	uint32_t ptime;             /* Packet time in [ms] (optional) */
 	const char *fmtp;
 	auenc_update_h *encupdh;
 	auenc_encode_h *ench;

--- a/modules/l16/l16.c
+++ b/modules/l16/l16.c
@@ -71,16 +71,16 @@ static int decode(struct audec_state *st, int fmt, void *sampv, size_t *sampc,
 
 /* See RFC 3551 */
 static struct aucodec l16v[NR_CODECS] = {
-{LE_INIT,    0, "L16", 48000, 48000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT, "10", "L16", 44100, 44100, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 32000, 32000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 16000, 16000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16",  8000,  8000, 2, 2, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 48000, 48000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT, "11", "L16", 44100, 44100, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 32000, 32000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16", 16000, 16000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
-{LE_INIT,    0, "L16",  8000,  8000, 1, 1, 0, 0, encode, 0, decode, 0, 0, 0},
+{LE_INIT,    0, "L16", 48000, 48000, 2, 2,  5, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT, "10", "L16", 44100, 44100, 2, 2,  5, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", 32000, 32000, 2, 2, 10, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", 16000, 16000, 2, 2, 20, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16",  8000,  8000, 2, 2, 20, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", 48000, 48000, 1, 1, 10, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT, "11", "L16", 44100, 44100, 1, 1, 10, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", 32000, 32000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", 16000, 16000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16",  8000,  8000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
 };
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1782,6 +1782,14 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 
 	telev_set_srate(a->telev, ac->crate);
 
+	/* use a codec-specific ptime */
+	if (ac->ptime) {
+		const size_t sz = aufmt_sample_size(tx->src_fmt);
+
+		tx->ptime = ac->ptime;
+		tx->psize = sz * calc_nsamp(ac->srate, ac->ch, ac->ptime);
+	}
+
 	if (!tx->ausrc) {
 		err |= audio_start(a);
 	}


### PR DESCRIPTION
- add optional ptime (in ms) packet time to each codec,
  which can be used to override the default

- update l16.so with some ptime values to keep the
  packet size below a common MTU (1500):

  48000/2 -> 5ms
  44100/2 -> 5ms
  32000/2 -> 10ms
  16000/2 -> 20ms
  ... etc ...