### PR TITLE
add config for audio receive buffer size

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -251,6 +251,7 @@ struct config_audio {
 	int play_fmt;           /**< Audio playback sample format   */
 	int enc_fmt;            /**< Audio encoder sample format    */
 	int dec_fmt;            /**< Audio decoder sample format    */
+	struct range buffer;    /**< Audio receive buffer in [ms]   */
 };
 
 /** Video */

--- a/src/audio.c
+++ b/src/audio.c
@@ -1541,19 +1541,17 @@ static int start_player(struct aurx *rx, struct audio *a)
 		prm.fmt        = rx->play_fmt;
 
 		if (!rx->aubuf) {
-			const size_t ssz = aufmt_sample_size(rx->play_fmt);
-
+			const size_t sz = aufmt_sample_size(rx->play_fmt);
 			const size_t ptime_min = a->cfg.buffer.min;
 			const size_t ptime_max = a->cfg.buffer.max;
-
 			size_t min_sz;
 			size_t max_sz;
 
 			if (!ptime_min || !ptime_max)
 				return EINVAL;
 
-			min_sz = ssz*calc_nsamp(prm.srate, prm.ch, ptime_min);
-			max_sz = ssz*calc_nsamp(prm.srate, prm.ch, ptime_max);
+			min_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_min);
+			max_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_max);
 
 			debug("audio: create recv buffer"
 			      " [%zu - %zu ms]"

--- a/src/audio.c
+++ b/src/audio.c
@@ -1541,17 +1541,33 @@ static int start_player(struct aurx *rx, struct audio *a)
 		prm.fmt        = rx->play_fmt;
 
 		if (!rx->aubuf) {
-			size_t psize;
-			size_t sz = aufmt_sample_size(rx->play_fmt);
+			const size_t ssz = aufmt_sample_size(rx->play_fmt);
 
-			psize = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
+			const size_t ptime_min = a->cfg.buffer.min;
+			const size_t ptime_max = a->cfg.buffer.max;
 
-			rx->aubuf_maxsz = psize * 8;
+			size_t min_sz;
+			size_t max_sz;
 
-			err = aubuf_alloc(&rx->aubuf, psize * 1,
-					  rx->aubuf_maxsz);
-			if (err)
+			if (!ptime_min || !ptime_max)
+				return EINVAL;
+
+			min_sz = ssz*calc_nsamp(prm.srate, prm.ch, ptime_min);
+			max_sz = ssz*calc_nsamp(prm.srate, prm.ch, ptime_max);
+
+			debug("audio: create recv buffer"
+			      " [%zu - %zu ms]"
+			      " [%zu - %zu bytes]\n",
+			      ptime_min, ptime_max, min_sz, max_sz);
+
+			err = aubuf_alloc(&rx->aubuf, min_sz, max_sz);
+			if (err) {
+				warning("audio: aubuf alloc error (%m)\n",
+					err);
 				return err;
+			}
+
+			rx->aubuf_maxsz = max_sz;
 		}
 
 		err = auplay_alloc(&rx->auplay, baresip_auplayl(),

--- a/src/config.c
+++ b/src/config.c
@@ -49,6 +49,7 @@ static struct config core_config = {
 		AUFMT_S16LE,
 		AUFMT_S16LE,
 		AUFMT_S16LE,
+		{20, 160},
 	},
 
 	/** Video */
@@ -277,6 +278,12 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	conf_get_aufmt(conf, "auplay_format", &cfg->audio.play_fmt);
 	conf_get_aufmt(conf, "auenc_format", &cfg->audio.enc_fmt);
 	conf_get_aufmt(conf, "audec_format", &cfg->audio.dec_fmt);
+
+	conf_get_range(conf, "audio_buffer", &cfg->audio.buffer);
+	if (!cfg->audio.buffer.min || !cfg->audio.buffer.max) {
+		warning("config: audio_buffer cannot be zero\n");
+		return EINVAL;
+	}
 
 	/* Video */
 	(void)conf_get_csv(conf, "video_source",
@@ -559,6 +566,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "auplay_format\t\ts16\t\t# s16, float, ..\n"
 			  "auenc_format\t\ts16\t\t# s16, float, ..\n"
 			  "audec_format\t\ts16\t\t# s16, float, ..\n"
+			  "audio_buffer\t\t%H\t\t# ms\n"
 			  ,
 			  poll_method_name(poll_method_best()),
 			  default_cafile(),
@@ -566,7 +574,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  cfg->call.max_calls,
 			  default_audio_device(),
 			  default_audio_device(),
-			  default_audio_device());
+			  default_audio_device(),
+			  range_print, &cfg->audio.buffer);
 
 	err |= re_hprintf(pf,
 			  "\n# Video\n"


### PR DESCRIPTION
The audio receive/decode path has an audio buffer with de-jitter.

This patch makes the size run-time configurable:

`audio_buffer            20-100          # ms`
