### PR TITLE
Jack connect config

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -174,6 +174,8 @@ opus_bitrate		28000 # 6000-510000
 #opus_samplerate	48000
 #opus_packet_loss	10	# 0-100 percent
 
+#jack_connect_ports	yes
+
 # Selfview
 video_selfview		window # {window,pip}
 #selfview_size		64x64

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -89,8 +89,8 @@ static int start_jack(struct auplay_st *st)
 	jack_nframes_t engine_srate;
 
 	bool jack_connect_ports = true;
-        (void)conf_get_bool(conf, "jack_connect_ports",
-                           &jack_connect_ports);
+	(void)conf_get_bool(conf, "jack_connect_ports",
+				  &jack_connect_ports);
 
 	/* open a client connection to the JACK server */
 
@@ -175,7 +175,8 @@ static int start_jack(struct auplay_st *st)
 
 		for (ch=0; ch<st->prm.ch; ch++) {
 
-			if (jack_connect (st->client, jack_port_name (st->portv[ch]),
+			if (jack_connect (st->client,
+					  jack_port_name (st->portv[ch]),
 					  ports[ch])) {
 				warning("jack: cannot connect output ports\n");
 			}

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -79,6 +79,7 @@ static void auplay_destructor(void *arg)
 
 static int start_jack(struct auplay_st *st)
 {
+	struct conf *conf = conf_cur();
 	const char **ports;
 	const char *client_name = "baresip";
 	const char *server_name = NULL;
@@ -86,6 +87,10 @@ static int start_jack(struct auplay_st *st)
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;
+
+	bool jack_connect_ports = true;
+        (void)conf_get_bool(conf, "jack_connect_ports",
+                           &jack_connect_ports);
 
 	/* open a client connection to the JACK server */
 
@@ -159,22 +164,25 @@ static int start_jack(struct auplay_st *st)
 	 * it.
 	 */
 
-	ports = jack_get_ports (st->client, NULL, NULL,
-				JackPortIsInput);
-	if (ports == NULL) {
-		warning("jack: no physical playback ports\n");
-		return ENODEV;
-	}
-
-	for (ch=0; ch<st->prm.ch; ch++) {
-
-		if (jack_connect (st->client, jack_port_name (st->portv[ch]),
-				  ports[ch])) {
-			warning("jack: cannot connect output ports\n");
+	if (jack_connect_ports) {
+		info("jack: connecting default input ports\n");
+		ports = jack_get_ports (st->client, NULL, NULL,
+					JackPortIsInput);
+		if (ports == NULL) {
+			warning("jack: no physical playback ports\n");
+			return ENODEV;
 		}
-	}
 
-	jack_free(ports);
+		for (ch=0; ch<st->prm.ch; ch++) {
+
+			if (jack_connect (st->client, jack_port_name (st->portv[ch]),
+					  ports[ch])) {
+				warning("jack: cannot connect output ports\n");
+			}
+		}
+
+		jack_free(ports);
+	}
 
 	return 0;
 }

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -81,7 +81,7 @@ static int start_jack(struct ausrc_st *st)
 
 	bool jack_connect_ports = true;
 	(void)conf_get_bool(conf, "jack_connect_ports",
-				&jack_connect_ports);
+				  &jack_connect_ports);
 
 	/* open a client connection to the JACK server */
 
@@ -148,7 +148,7 @@ static int start_jack(struct ausrc_st *st)
 	}
 
 	if (jack_connect_ports) {
-                info("jack: connecting default output ports\n");
+		info("jack: connecting default output ports\n");
 		ports = jack_get_ports (st->client, NULL, NULL,
 					JackPortIsOutput);
 		if (ports == NULL) {

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -70,6 +70,7 @@ static void ausrc_destructor(void *arg)
 
 static int start_jack(struct ausrc_st *st)
 {
+	struct conf *conf = conf_cur();
 	const char **ports;
 	const char *client_name = "baresip";
 	const char *server_name = NULL;
@@ -77,6 +78,10 @@ static int start_jack(struct ausrc_st *st)
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;
+
+	bool jack_connect_ports = true;
+	(void)conf_get_bool(conf, "jack_connect_ports",
+				&jack_connect_ports);
 
 	/* open a client connection to the JACK server */
 
@@ -142,22 +147,24 @@ static int start_jack(struct ausrc_st *st)
 		return ENODEV;
 	}
 
-	ports = jack_get_ports (st->client, NULL, NULL,
-				JackPortIsOutput);
-	if (ports == NULL) {
-		warning("jack: no physical playback ports\n");
-		return ENODEV;
-	}
-
-	for (ch=0; ch<st->prm.ch; ch++) {
-
-		if (jack_connect(st->client, ports[ch],
-				 jack_port_name(st->portv[ch]))) {
-			warning("jack: cannot connect output ports\n");
+	if (jack_connect_ports) {
+                info("jack: connecting default output ports\n");
+		ports = jack_get_ports (st->client, NULL, NULL,
+					JackPortIsOutput);
+		if (ports == NULL) {
+			warning("jack: no physical playback ports\n");
+			return ENODEV;
 		}
-	}
 
-	jack_free(ports);
+		for (ch=0; ch<st->prm.ch; ch++) {
+			if (jack_connect(st->client, ports[ch],
+					 jack_port_name(st->portv[ch]))) {
+				warning("jack: cannot connect output ports\n");
+			}
+		}
+
+		jack_free(ports);
+	}
 
 	return 0;
 }

--- a/src/config.c
+++ b/src/config.c
@@ -903,6 +903,9 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "\n");
 	(void)re_fprintf(f, "vumeter_stderr\t\tyes\n");
 
+        (void)re_fprintf(f, "\n");
+        (void)re_fprintf(f, "#jack_connect_ports\tyes\n");
+
 	(void)re_fprintf(f,
 			"\n# Selfview\n"
 			"video_selfview\t\twindow # {window,pip}\n"

--- a/src/config.c
+++ b/src/config.c
@@ -903,8 +903,8 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "\n");
 	(void)re_fprintf(f, "vumeter_stderr\t\tyes\n");
 
-        (void)re_fprintf(f, "\n");
-        (void)re_fprintf(f, "#jack_connect_ports\tyes\n");
+	(void)re_fprintf(f, "\n");
+	(void)re_fprintf(f, "#jack_connect_ports\tyes\n");
 
 	(void)re_fprintf(f,
 			"\n# Selfview\n"


### PR DESCRIPTION
Second attempt... Fixed formatting.

Add option to allow baresip not to make jack connections once the call is up and running.  My use case is radio broadcasting where the routing will be switched by the playout system.