### PR TITLE
make reg->af available for use by best_effort_af

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -222,6 +222,7 @@ void reg_unregister(struct reg *reg);
 bool reg_isok(const struct reg *reg);
 int  reg_debug(struct re_printf *pf, const struct reg *reg);
 int  reg_status(struct re_printf *pf, const struct reg *reg);
+int  reg_af(const struct reg *reg);
 
 
 /*

--- a/src/reg.c
+++ b/src/reg.c
@@ -120,8 +120,6 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 		n_bindings = sip_msg_hdr_count(msg, SIP_HDR_CONTACT);
 		reg->af    = sipmsg_af(msg);
 
-		ua_set_media_af(reg->ua, reg->af);
-
 		if (msg->scode != reg->scode) {
 			ua_printf(reg->ua, "{%d/%s/%s} %u %r (%s)"
 				  " [%u binding%s]\n",
@@ -268,4 +266,13 @@ int reg_status(struct re_printf *pf, const struct reg *reg)
 		return 0;
 
 	return re_hprintf(pf, " %s %s", print_scode(reg->scode), reg->srv);
+}
+
+
+int reg_af(const struct reg *reg)
+{
+	if (!reg)
+		return 0;
+
+	return reg->af;
 }


### PR DESCRIPTION
Do not update ua->af_media by reg.c  register_handler().  Instead make reg->af available for use by ua.c best_effort_af().