### PR TITLE
add support for STUN uri used in MNAT api

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ zrtp          ZRTP media encryption module
 * RFC 6464  A RTP Header Extension for Client-to-Mixer Audio Level Indication
 * RFC 6716  Definition of the Opus Audio Codec
 * RFC 6886  NAT Port Mapping Protocol (NAT-PMP)
+* RFC 7064  URI Scheme for STUN Protocol
+* RFC 7065  TURN Uniform Resource Identifiers
 * RFC 7310  RTP Payload Format for Standard apt-X and Enhanced apt-X Codecs
 * RFC 7587  RTP Payload Format for the Opus Speech and Audio Codec
 * RFC 7741  RTP Payload Format for VP8 Video

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -186,7 +186,6 @@ video_selfview		window # {window,pip}
 #selfview_size		64x64
 
 # ICE
-ice_turn		no
 ice_debug		no
 ice_nomination		regular	# {regular,aggressive}
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1244,6 +1244,30 @@ int  stream_debug(struct re_printf *pf, const struct stream *s);
 
 
 /*
+ * STUN URI
+ */
+
+enum stun_scheme {
+	STUN_SCHEME_STUN,
+	STUN_SCHEME_STUNS,
+	STUN_SCHEME_TURN,
+	STUN_SCHEME_TURNS,
+};
+
+struct stun_uri {
+	enum stun_scheme scheme;
+	char *host;
+	uint16_t port;
+};
+
+int stunuri_decode(struct stun_uri **sup, const struct pl *pl);
+int stunuri_set_host(struct stun_uri *su, const char *host);
+int stunuri_set_port(struct stun_uri *su, uint16_t port);
+int stunuri_print(struct re_printf *pf, const struct stun_uri *su);
+const char *stunuri_scheme_name(enum stun_scheme scheme);
+
+
+/*
  * Media NAT
  */
 
@@ -1260,7 +1284,7 @@ typedef void (mnat_connected_h)(const struct sa *raddr1,
 
 typedef int (mnat_sess_h)(struct mnat_sess **sessp,
 			  const struct mnat *mnat, struct dnsc *dnsc,
-			  int af, const char *srv, uint16_t port,
+			  int af, const struct stun_uri *srv,
 			  const char *user, const char *pass,
 			  struct sdp_session *sdp, bool offerer,
 			  mnat_estab_h *estabh, void *arg);

--- a/modules/natpmp/natpmp.c
+++ b/modules/natpmp/natpmp.c
@@ -196,7 +196,7 @@ static void natpmp_resp_handler(int err, const struct natpmp_resp *resp,
 
 static int session_alloc(struct mnat_sess **sessp,
 			 const struct mnat *mnat, struct dnsc *dnsc,
-			 int af, const char *srv, uint16_t port,
+			 int af, const struct stun_uri *srv,
 			 const char *user, const char *pass,
 			 struct sdp_session *ss, bool offerer,
 			 mnat_estab_h *estabh, void *arg)
@@ -204,13 +204,13 @@ static int session_alloc(struct mnat_sess **sessp,
 	struct mnat_sess *sess;
 	(void)mnat;
 	(void)af;
-	(void)port;
+	(void)srv;
 	(void)user;
 	(void)pass;
 	(void)ss;
 	(void)offerer;
 
-	if (!sessp || !dnsc || !srv || !ss || !estabh)
+	if (!sessp || !dnsc || !ss || !estabh)
 		return EINVAL;
 
 	sess = mem_zalloc(sizeof(*sess), session_destructor);

--- a/src/call.c
+++ b/src/call.c
@@ -738,7 +738,7 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	if (acc->mnat) {
 		err = acc->mnat->sessh(&call->mnats, acc->mnat,
 				       dnsc, call->af,
-				       acc->stun_host, acc->stun_port,
+				       acc->stun_host,
 				       acc->stun_user, acc->stun_pass,
 				       call->sdp, !got_offer,
 				       mnat_handler, call);

--- a/src/config.c
+++ b/src/config.c
@@ -909,7 +909,6 @@ int config_write_template(const char *file, const struct config *cfg)
 
 	(void)re_fprintf(f,
 			"\n# ICE\n"
-			"ice_turn\t\tno\n"
 			"ice_debug\t\tno\n"
 			"ice_nomination\t\tregular\t# {regular,aggressive}\n");
 

--- a/src/core.h
+++ b/src/core.h
@@ -70,8 +70,7 @@ struct account {
 	char *sipnat;                /**< SIP Nat mechanism                  */
 	char *stun_user;             /**< STUN Username                      */
 	char *stun_pass;             /**< STUN Password                      */
-	char *stun_host;             /**< STUN Hostname                      */
-	uint16_t stun_port;          /**< STUN Port number                   */
+	struct stun_uri *stun_host;  /**< STUN Server                        */
 	struct le vcv[4];            /**< List elements for vidcodecl        */
 	struct list vidcodecl;       /**< List of preferred video-codecs     */
 	bool mwi;                    /**< MWI on/off                         */

--- a/src/srcs.mk
+++ b/src/srcs.mk
@@ -36,6 +36,7 @@ SRCS	+= rtpstat.c
 SRCS	+= sdp.c
 SRCS	+= sipreq.c
 SRCS	+= stream.c
+SRCS	+= stunuri.c
 SRCS	+= timer.c
 SRCS	+= timestamp.c
 SRCS	+= ua.c

--- a/src/stunuri.c
+++ b/src/stunuri.c
@@ -1,0 +1,141 @@
+/**
+ * @file stunuri.c URI Scheme for STUN/TURN Protocol
+ *
+ * Copyright (C) 2010 Creytiv.com
+ */
+
+#include <re.h>
+#include <baresip.h>
+#include "core.h"
+
+
+/*
+  https://tools.ietf.org/html/rfc7064
+  https://tools.ietf.org/html/rfc7065
+
+
+                          +-----------------------+
+                          | URI                   |
+                          +-----------------------+
+                          | stun:example.org      |
+                          | stuns:example.org     |
+                          | stun:example.org:8000 |
+                          +-----------------------+
+
+
+   +---------------------------------+----------+--------+-------------+
+   | URI                             | <secure> | <port> | <transport> |
+   +---------------------------------+----------+--------+-------------+
+   | turn:example.org                | false    |        |             |
+   | turns:example.org               | true     |        |             |
+   | turn:example.org:8000           | false    | 8000   |             |
+   | turn:example.org?transport=udp  | false    |        | UDP         |
+   | turn:example.org?transport=tcp  | false    |        | TCP         |
+   | turns:example.org?transport=tcp | true     |        | TLS         |
+   +---------------------------------+----------+--------+-------------+
+
+ */
+
+
+static void destructor(void *arg)
+{
+	struct stun_uri *su = arg;
+
+	mem_deref(su->host);
+}
+
+
+int stunuri_decode(struct stun_uri **sup, const struct pl *pl)
+{
+	struct stun_uri *su;
+	struct uri uri;
+	enum stun_scheme scheme;
+	int err;
+
+	if (!sup || !pl)
+		return EINVAL;
+
+	err = uri_decode(&uri, pl);
+	if (err) {
+		warning("stunuri: decode '%r' failed (%m)\n", pl, err);
+		return err;
+	}
+
+	if (0 == pl_strcasecmp(&uri.scheme, "stun"))
+		scheme = STUN_SCHEME_STUN;
+	else if (0 == pl_strcasecmp(&uri.scheme, "stuns"))
+		scheme = STUN_SCHEME_STUNS;
+	else if (0 == pl_strcasecmp(&uri.scheme, "turn"))
+		scheme = STUN_SCHEME_TURN;
+	else if (0 == pl_strcasecmp(&uri.scheme, "turns"))
+		scheme = STUN_SCHEME_TURNS;
+	else {
+		warning("stunuri: scheme not supported (%r)\n", &uri.scheme);
+		return ENOTSUP;
+	}
+
+	su = mem_zalloc(sizeof(*su), destructor);
+	if (!su)
+		return ENOMEM;
+
+	su->scheme = scheme;
+	err = pl_strdup(&su->host, &uri.host);
+	su->port = uri.port;
+
+	if (err)
+		mem_deref(su);
+	else
+		*sup = su;
+
+	return err;
+}
+
+
+int stunuri_set_host(struct stun_uri *su, const char *host)
+{
+	if (!su || !host)
+		return EINVAL;
+
+	su->host = mem_deref(su->host);
+
+	return str_dup(&su->host, host);
+}
+
+
+int stunuri_set_port(struct stun_uri *su, uint16_t port)
+{
+	if (!su)
+		return EINVAL;
+
+	su->port = port;
+
+	return 0;
+}
+
+
+int stunuri_print(struct re_printf *pf, const struct stun_uri *su)
+{
+	int err = 0;
+
+	if (!su)
+		return 0;
+
+	err |= re_hprintf(pf, "scheme=%s", stunuri_scheme_name(su->scheme));
+	err |= re_hprintf(pf, " host='%s'", su->host);
+	err |= re_hprintf(pf, " port=%u", su->port);
+
+	return err;
+}
+
+
+const char *stunuri_scheme_name(enum stun_scheme scheme)
+{
+	switch (scheme) {
+
+	case STUN_SCHEME_STUN:  return "stun";
+	case STUN_SCHEME_STUNS: return "stuns";
+	case STUN_SCHEME_TURN:  return "turn";
+	case STUN_SCHEME_TURNS: return "turns";
+	default: return "?";
+	}
+}

--- a/test/mock/mock_mnat.c
+++ b/test/mock/mock_mnat.c
@@ -54,7 +54,7 @@ static void tmr_handler(void *data)
 
 static int mnat_session_alloc(struct mnat_sess **sessp,
 			      const struct mnat *mnat, struct dnsc *dnsc,
-			      int af, const char *srv, uint16_t port,
+			      int af, const struct stun_uri *srv,
 			      const char *user, const char *pass,
 			      struct sdp_session *sdp, bool offerer,
 			      mnat_estab_h *estabh, void *arg)
@@ -64,7 +64,6 @@ static int mnat_session_alloc(struct mnat_sess **sessp,
 	(void)dnsc;
 	(void)af;
 	(void)srv;
-	(void)port;
 	(void)user;
 	(void)pass;
 	(void)sdp;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7064
https://tools.ietf.org/html/rfc7065

ice_turn yes|no config has been replaced by per account
stunserver:

    ;stunserver="turn:example.org:8000"