### PR TITLE
add ebuacip module

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Distributed under BSD license
   - Simple configuration files
   - MQTT (Message Queue Telemetry Transport) module
 
+* Profiles:
+  - EBU ACIP (Audio Contribution over IP) Profile
+
 
 ## Building
 
@@ -239,6 +242,7 @@ debug_cmd     Debug commands
 directfb      DirectFB video display module
 dshow         Windows DirectShow video source
 dtls_srtp     DTLS-SRTP end-to-end encryption
+ebuacip       EBU ACIP (Audio Contribution over IP) Profile
 echo          Echo server module
 evdev         Linux input driver
 fakevideo     Fake video input/output driver

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -288,11 +288,6 @@ struct config_net {
 	size_t nsc;             /**< Number of DNS nameservers      */
 };
 
-/** SDP */
-struct config_sdp {
-	bool ebuacip;           /**< Enable EBU-ACIP parameters     */
-};
-
 
 /** Core configuration */
 struct config {
@@ -307,8 +302,6 @@ struct config {
 	struct config_avt avt;
 
 	struct config_net net;
-
-	struct config_sdp sdp;
 };
 
 int config_parse_conf(struct config *cfg, const struct conf *conf);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -679,8 +679,8 @@ enum ua_event {
 	UA_EVENT_VU_TX,
 	UA_EVENT_VU_RX,
 	UA_EVENT_AUDIO_ERROR,
-	UA_EVENT_CALL_LOCAL_SDP,
-	UA_EVENT_CALL_REMOTE_SDP,
+	UA_EVENT_CALL_LOCAL_SDP,      /**< param: offer or answer */
+	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
 
 	UA_EVENT_MAX,
 };

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -686,6 +686,8 @@ enum ua_event {
 	UA_EVENT_VU_TX,
 	UA_EVENT_VU_RX,
 	UA_EVENT_AUDIO_ERROR,
+	UA_EVENT_CALL_LOCAL_SDP,
+	UA_EVENT_CALL_REMOTE_SDP,
 
 	UA_EVENT_MAX,
 };
@@ -1168,6 +1170,7 @@ int  audio_encoder_set(struct audio *a, const struct aucodec *ac,
 int  audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		       int pt_rx, const char *params);
 const struct aucodec *audio_codec(const struct audio *au, bool tx);
+struct config_audio *audio_config(struct audio *au);
 
 
 /*

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -282,6 +282,7 @@ MODULES   += vidbridge
 MODULES   += vidinfo
 MODULES   += vidloop
 MODULES   += vumeter
+MODULES   += ebuacip
 
 ifneq ($(HAVE_PTHREAD),)
 MODULES   += aubridge aufile

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -265,6 +265,7 @@ MODULES   += b2bua
 MODULES   += contact
 MODULES   += ctrl_tcp
 MODULES   += debug_cmd
+MODULES   += ebuacip
 MODULES   += echo
 MODULES   += fakevideo
 MODULES   += httpd
@@ -282,7 +283,6 @@ MODULES   += vidbridge
 MODULES   += vidinfo
 MODULES   += vidloop
 MODULES   += vumeter
-MODULES   += ebuacip
 
 ifneq ($(HAVE_PTHREAD),)
 MODULES   += aubridge aufile

--- a/modules/ebuacip/ebuacip.c
+++ b/modules/ebuacip/ebuacip.c
@@ -15,6 +15,11 @@
  *
  * Ref: https://tech.ebu.ch/docs/tech/tech3368.pdf
  *
+ * Example config:
+ *
+ \verbatim
+  ebuacip_jb_type       auto|fixed
+ \endverbatim
  */
 
 static char jb_type[16];

--- a/modules/ebuacip/ebuacip.c
+++ b/modules/ebuacip/ebuacip.c
@@ -1,0 +1,190 @@
+/**
+ * @file ebuacip.c  EBU ACIP (Audio Contribution over IP) Profile
+ *
+ * Copyright (C) 2010 Creytiv.com
+ */
+
+#include <re.h>
+#include <baresip.h>
+
+
+/**
+ * @defgroup ebuacip ebuacip
+ *
+ * EBU ACIP (Audio Contribution over IP) Profile
+ *
+ * Ref: https://tech.ebu.ch/docs/tech/tech3368.pdf
+ *
+ */
+
+static char jb_type[16];
+
+
+static int set_ebuacip_params(struct audio *au)
+{
+	struct stream *strm = audio_strm(au);
+	struct sdp_media *sdp = stream_sdpmedia(strm);
+	struct config *cfg = conf_config();
+	const struct config_avt *avt = &cfg->avt;
+	struct config_audio *audio = audio_config(au);
+	const struct list *lst;
+	struct le *le;
+	int jb_id = 0;
+	int err = 0;
+
+	info(".... ebuacip: adding SDP parameters\n");
+
+	/* set ebuacip version fixed value 0 for now. */
+	err |= sdp_media_set_lattr(sdp, false, "ebuacip", "version %i", 0);
+
+	/* set jb option, only one in our case */
+	err |= sdp_media_set_lattr(sdp, false, "ebuacip", "jb %i", jb_id);
+
+	/* define jb value in option */
+	if (0 == str_casecmp(jb_type, "auto")) {
+
+		err |= sdp_media_set_lattr(sdp, false,
+					   "ebuacip",
+					   "jbdef %i auto %d-%d",
+					   jb_id,
+					   audio->buffer.min,
+					   audio->buffer.max);
+	}
+	else if (0 == str_casecmp(jb_type, "fixed")) {
+
+		/* define jb value in option from audio buffer min value */
+		err |= sdp_media_set_lattr(sdp, false,
+					   "ebuacip",
+					   "jbdef %i fixed %d",
+					   jb_id,
+					   audio->buffer.min);
+	}
+
+	/* set QOS recomendation use tos / 4 to set DSCP value */
+	err |= sdp_media_set_lattr(sdp, false, "ebuacip", "qosrec %u",
+				   avt->rtp_tos / 4);
+
+	/* EBU ACIP FEC:: NOT SET IN BARESIP */
+
+	lst = sdp_media_format_lst(sdp, true);
+	for (le = list_head(lst); le; le = le->next) {
+
+		const struct sdp_format *fmt = le->data;
+		struct aucodec *ac = fmt->data;
+
+		if (!fmt->sup)
+			continue;
+
+		if (!fmt->data)
+			continue;
+
+		if (ac->ptime) {
+			err |= sdp_media_set_lattr(sdp, false, "ebuacip",
+						   "plength %s %u",
+						   fmt->id, ac->ptime);
+		}
+	}
+
+	return err;
+}
+
+
+static bool ebuacip_handler(const char *name, const char *value, void *arg)
+{
+	struct audio *au = arg;
+	struct config_audio *cfg = audio_config(au);
+	struct sdp_media *sdp;
+	struct pl type, val, val2;
+	(void)name;
+
+	info(".... ebuacip: param '%s'\n", value);
+
+	/* check type first, if not fixed or auto, return false */
+
+	if (0 == re_regex(value, str_len(value),
+			  "jbdef [0-9]+ [a-z]+ [0-9]+-[0-9]+",
+			  NULL, &type, &val, &val2)) {
+
+		/* check for type auto */
+		if (0 == pl_strcasecmp(&type, "auto")) {
+			/* set audio buffer from min and max value*/
+			cfg->buffer.min = pl_u32(&val);
+			cfg->buffer.max = pl_u32(&val2);
+		}
+	}
+	else if (0 == re_regex(value, str_len(value),
+			       "jbdef [0-9]+ [a-z]+ [0-9]+",
+			       NULL, &type, &val)) {
+
+		/* check type fixed */
+		if (0 == pl_strcasecmp(&type, "fixed")) {
+			/* set both audio buffer min and max value to val*/
+			cfg->buffer.min = pl_u32(&val);
+			cfg->buffer.max = pl_u32(&val);
+		}
+	}
+	else {
+		return false;
+	}
+
+	sdp = stream_sdpmedia(audio_strm(au));
+	sdp_media_del_lattr(sdp, "ebuacip");
+
+	return true;
+}
+
+
+static void ua_event_handler(struct ua *ua, enum ua_event ev,
+			     struct call *call, const char *prm, void *arg)
+{
+	struct audio *au;
+	(void)prm;
+	(void)arg;
+
+#if 1
+	info(".... ebuacip: [ ua=%s call=%s ] event: %s (%s)\n",
+	      ua_aor(ua), call_id(call), uag_event_str(ev), prm);
+#endif
+
+	switch (ev) {
+
+	case UA_EVENT_CALL_LOCAL_SDP:
+		info(".... ebuacip: CALL_CONNECT event\n");
+		set_ebuacip_params(call_audio(call));
+		break;
+
+	case UA_EVENT_CALL_REMOTE_SDP:
+		info(".... ebuacip: SDP_OFFER event\n");
+		au = call_audio(call);
+		sdp_media_rattr_apply(stream_sdpmedia(audio_strm(au)),
+				      "ebuacip", ebuacip_handler, au);
+		break;
+
+	default:
+		break;
+	}
+}
+
+
+static int module_init(void)
+{
+	conf_get_str(conf_cur(), "ebuacip_jb_type", jb_type, sizeof(jb_type));
+
+	return uag_event_register(ua_event_handler, NULL);
+}
+
+
+static int module_close(void)
+{
+	uag_event_unregister(ua_event_handler);
+
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(ebuacip) = {
+	"ebuacip",
+	"application",
+	module_init,
+	module_close
+};

--- a/modules/ebuacip/ebuacip.c
+++ b/modules/ebuacip/ebuacip.c
@@ -150,7 +150,8 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_CALL_LOCAL_SDP:
 		info(".... ebuacip: CALL_CONNECT event\n");
-		set_ebuacip_params(call_audio(call));
+		if (0 == str_casecmp(prm, "offer"))
+			set_ebuacip_params(call_audio(call));
 		break;
 
 	case UA_EVENT_CALL_REMOTE_SDP:

--- a/modules/ebuacip/module.mk
+++ b/modules/ebuacip/module.mk
@@ -1,0 +1,10 @@
+#
+# module.mk
+#
+# Copyright (C) 2010 Creytiv.com
+#
+
+MOD		:= ebuacip
+$(MOD)_SRCS	+= ebuacip.c
+
+include mk/mod.mk

--- a/src/audio.c
+++ b/src/audio.c
@@ -2288,6 +2288,13 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 }
 
 
+/**
+ * Accessor function to audio configuration
+ *
+ * @param au Audio object
+ *
+ * @return Audio configuration
+ */
 struct config_audio *audio_config(struct audio *au)
 {
 	return au ? &au->cfg : NULL;

--- a/src/call.c
+++ b/src/call.c
@@ -389,6 +389,9 @@ static int update_media(struct call *call)
 
 	debug("call: update media\n");
 
+	ua_event(call->ua, UA_EVENT_CALL_REMOTE_SDP, call,
+		 call->got_offer ? "offer" : "answer");
+
 	/* media attributes */
 	audio_sdp_attr_decode(call->audio);
 
@@ -1051,6 +1054,9 @@ int call_answer(struct call *call, uint16_t scode)
 			return err;
 	}
 
+	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, (struct call *)call,
+		 "%s", !call->got_offer ? "offer" : "answer");
+
 	err = sdp_encode(&desc, call->sdp, !call->got_offer);
 	if (err)
 		return err;
@@ -1127,6 +1133,12 @@ int call_hold(struct call *call, bool hold)
 
 int call_sdp_get(const struct call *call, struct mbuf **descp, bool offer)
 {
+	if (!call)
+		return EINVAL;
+
+	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, (struct call *)call,
+		 "%s", offer ? "offer" : "answer");
+
 	return sdp_encode(descp, call->sdp, offer);
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -1054,7 +1054,7 @@ int call_answer(struct call *call, uint16_t scode)
 			return err;
 	}
 
-	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, (struct call *)call,
+	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call,
 		 "%s", !call->got_offer ? "offer" : "answer");
 
 	err = sdp_encode(&desc, call->sdp, !call->got_offer);
@@ -1135,9 +1135,6 @@ int call_sdp_get(const struct call *call, struct mbuf **descp, bool offer)
 {
 	if (!call)
 		return EINVAL;
-
-	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, (struct call *)call,
-		 "%s", offer ? "offer" : "answer");
 
 	return sdp_encode(descp, call->sdp, offer);
 }
@@ -1806,6 +1803,8 @@ static int send_invite(struct call *call)
 	int err;
 
 	routev[0] = account_outbound(call->acc, 0);
+
+	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call, "offer");
 
 	err = call_sdp_get(call, &desc, true);
 	if (err)

--- a/src/config.c
+++ b/src/config.c
@@ -81,11 +81,6 @@ static struct config core_config = {
 		{ {""} },
 		0
 	},
-
-	/* SDP */
-	{
-		false
-	},
 };
 
 
@@ -330,9 +325,6 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_apply(conf, "dns_server", dns_server_handler, &cfg->net);
 	(void)conf_get_str(conf, "net_interface",
 			   cfg->net.ifname, sizeof(cfg->net.ifname));
-
-	/* SDP */
-	(void)conf_get_bool(conf, "sdp_ebuacip", &cfg->sdp.ebuacip);
 
 	return err;
 }

--- a/src/event.c
+++ b/src/event.c
@@ -205,6 +205,8 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_VU_TX:                return "VU_TX_REPORT";
 	case UA_EVENT_VU_RX:                return "VU_RX_REPORT";
 	case UA_EVENT_AUDIO_ERROR:          return "AUDIO_ERROR";
+	case UA_EVENT_CALL_LOCAL_SDP:       return "CALL_LOCAL_SDP";
+	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
 	default: return "?";
 	}
 }


### PR DESCRIPTION
This patch moves the EBUACIP specific code from core
to a new module called `ebuacip.so`

The functionality is the same.

Please review: @Ola-Palm @djhenley @premultiply 