### PR TITLE
Avformat add audio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
     apt:
         packages:
         - libavcodec-dev
+        - libavformat-dev
         - libgtk2.0-dev
         - libjack-jackd2-dev
         - libmpg123-dev
@@ -30,6 +31,7 @@ addons:
         packages:
         - codec2
         - fdk-aac
+        - ffmpeg
         - jack
         - mpg123
         - spandsp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: xenial
 language: c
 
 os:

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -150,7 +150,7 @@ void avformat_audio_decode(struct shared *st, AVPacket *pkt)
 		return;
 
 #else
-	ret = avcodec_decode_audio4(st->au.ctx, frame, &got_frame, pkt);
+	ret = avcodec_decode_audio4(st->au.ctx, &frame, &got_frame, pkt);
 	if (ret < 0 || !got_frame)
 		return;
 #endif

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -27,7 +27,7 @@ static void audio_destructor(void *arg)
 {
 	struct ausrc_st *st = arg;
 
-	shared_set_audio(st->shared, NULL);
+	avformat_shared_set_audio(st->shared, NULL);
 	mem_deref(st->shared);
 }
 
@@ -114,7 +114,7 @@ int avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		goto out;
 	}
 
-	shared_set_audio(st->shared, st);
+	avformat_shared_set_audio(st->shared, st);
 
  out:
 	if (err)

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -134,7 +134,7 @@ void avformat_audio_decode(struct shared *st, AVPacket *pkt)
 	int got_frame;
 #endif
 
-	if (!st->au.ctx)
+	if (!st || !st->au.ctx)
 		return;
 
 	memset(&frame, 0, sizeof(frame));

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -1,0 +1,161 @@
+/**
+ * @file avformat/audio.c  libavformat media-source -- audio
+ *
+ * Copyright (C) 2010 - 2020 Creytiv.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <pthread.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include "mod_avformat.h"
+
+
+struct ausrc_st {
+	const struct ausrc *as;  /* base class */
+
+	struct shared *shared;
+	ausrc_read_h *readh;
+	ausrc_error_h *errh;
+	void *arg;
+};
+
+
+static void audio_destructor(void *arg)
+{
+	struct ausrc_st *st = arg;
+
+	shared_set_audio(st->shared, NULL);
+	mem_deref(st->shared);
+}
+
+
+static enum AVSampleFormat aufmt_to_avsampleformat(enum aufmt fmt)
+{
+	switch (fmt) {
+
+	case AUFMT_S16LE: return AV_SAMPLE_FMT_S16;
+	case AUFMT_FLOAT: return AV_SAMPLE_FMT_FLT;
+	default:          return AV_SAMPLE_FMT_NONE;
+	}
+}
+
+
+int avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
+			 struct media_ctx **ctx,
+			 struct ausrc_prm *prm, const char *dev,
+			 ausrc_read_h *readh, ausrc_error_h *errh, void *arg)
+{
+	struct ausrc_st *st;
+	struct shared *sh;
+	enum AVSampleFormat format;
+	int err = 0;
+
+	if (!stp || !as || !prm || !readh)
+		return EINVAL;
+
+	info("avformat: audio: loading input file '%s'\n", dev);
+
+	format = aufmt_to_avsampleformat(prm->fmt);
+	if (format == AV_SAMPLE_FMT_NONE) {
+		warning("avformat: audio: unsupported sampleformat (%s)\n",
+			aufmt_name(prm->fmt));
+		return ENOTSUP;
+	}
+
+	st = mem_zalloc(sizeof(*st), audio_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->as    = as;
+	st->readh = readh;
+	st->errh  = errh;
+	st->arg   = arg;
+
+	/* todo: also lookup "dev" ? */
+	if (ctx && *ctx && (*ctx)->id && !strcmp((*ctx)->id, "avformat")) {
+		st->shared = mem_ref(*ctx);
+	}
+	else {
+		err = avformat_shared_alloc(&st->shared, dev, prm->srate,
+					    0, 0);
+		if (err)
+			goto out;
+
+		if (ctx)
+			*ctx = (struct media_ctx *)st->shared;
+	}
+
+	sh = st->shared;
+
+	if (st->shared->au.idx < 0 || !st->shared->au.ctx) {
+		info("avformat: audio: media file has no audio stream\n");
+		err = ENOSTR;
+		goto out;
+	}
+
+	if (sh->au.ctx->sample_rate != (int)prm->srate ||
+	    sh->au.ctx->channels != prm->ch) {
+		info("avformat: audio: samplerate/channels"
+		     " mismatch: param=%u/%u, file=%u/%u\n",
+		     prm->srate, prm->ch,
+		     sh->au.ctx->sample_rate, sh->au.ctx->channels);
+		err = ENOTSUP;
+		goto out;
+	}
+
+	if (format != sh->au.ctx->sample_fmt) {
+		info("avformat: audio: sample format mismatch:"
+		     " param=%s, file=%s\n",
+		     av_get_sample_fmt_name(format),
+		     av_get_sample_fmt_name(sh->au.ctx->sample_fmt));
+		err = ENOTSUP;
+		goto out;
+	}
+
+	shared_set_audio(st->shared, st);
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}
+
+
+void avformat_audio_decode(struct shared *st, AVPacket *pkt)
+{
+	AVFrame avframe;
+	int ret;
+
+	if (!st->au.ctx)
+		return;
+
+	memset(&avframe, 0, sizeof(avframe));
+
+	ret = avcodec_send_packet(st->au.ctx, pkt);
+	if (ret < 0)
+		return;
+
+	ret = avcodec_receive_frame(st->au.ctx, &avframe);
+	if (ret < 0)
+		return;
+
+	/* NOTE: pass timestamp to application */
+
+	lock_read_get(st->lock);
+
+	if (st->ausrc_st && st->ausrc_st->readh) {
+		st->ausrc_st->readh(avframe.data[0],
+				    avframe.nb_samples * avframe.channels,
+				    st->ausrc_st->arg);
+	}
+
+	lock_rel(st->lock);
+
+	av_frame_unref(&avframe);
+}

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -79,8 +79,7 @@ int avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		st->shared = mem_ref(*ctx);
 	}
 	else {
-		err = avformat_shared_alloc(&st->shared, dev, prm->srate,
-					    0, 0);
+		err = avformat_shared_alloc(&st->shared, dev);
 		if (err)
 			goto out;
 
@@ -92,7 +91,7 @@ int avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	if (st->shared->au.idx < 0 || !st->shared->au.ctx) {
 		info("avformat: audio: media file has no audio stream\n");
-		err = ENOSTR;
+		err = ENOENT;
 		goto out;
 	}
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -195,8 +195,7 @@ static int open_codec(struct stream *s, const struct AVStream *strm, int i,
 }
 
 
-int avformat_shared_alloc(struct shared **shp, const char *dev,
-			  uint32_t srate, int width, int height)
+int avformat_shared_alloc(struct shared **shp, const char *dev)
 {
 	struct shared *st;
 	unsigned i;

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -235,6 +235,8 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 		const struct AVStream *strm = st->ic->streams[i];
 		AVCodecContext *ctx;
 
+#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
+
 		ctx = avcodec_alloc_context3(NULL);
 		if (!ctx) {
 			err = ENOMEM;
@@ -247,6 +249,9 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 			err = EPROTO;
 			goto out;
 		}
+#else
+		ctx = strm->codec;
+#endif
 
 		switch (ctx->codec_type) {
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -294,7 +294,7 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 }
 
 
-void shared_set_audio(struct shared *sh, struct ausrc_st *st)
+void avformat_shared_set_audio(struct shared *sh, struct ausrc_st *st)
 {
 	if (!sh)
 		return;
@@ -305,7 +305,7 @@ void shared_set_audio(struct shared *sh, struct ausrc_st *st)
 }
 
 
-void shared_set_video(struct shared *sh, struct vidsrc_st *st)
+void avformat_shared_set_video(struct shared *sh, struct vidsrc_st *st)
 {
 	if (!sh)
 		return;

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -59,11 +59,15 @@ static void shared_destructor(void *arg)
 		pthread_join(st->thread, NULL);
 	}
 
-	if (st->au.ctx)
+	if (st->au.ctx) {
 		avcodec_close(st->au.ctx);
+		avcodec_free_context(&st->au.ctx);
+	}
 
-	if (st->vid.ctx)
+	if (st->vid.ctx) {
 		avcodec_close(st->vid.ctx);
+		avcodec_free_context(&st->vid.ctx);
+	}
 
 	if (st->ic)
 		avformat_close_input(&st->ic);

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -1,7 +1,7 @@
 /**
- * @file avformat.c  libavformat video-source
+ * @file avformat.c  libavformat media-source
  *
- * Copyright (C) 2010 - 2015 Creytiv.com
+ * Copyright (C) 2010 - 2020 Creytiv.com
  */
 #define _DEFAULT_SOURCE 1
 #define _BSD_SOURCE 1
@@ -14,241 +14,228 @@
 #include <libavformat/avformat.h>
 #include <libavdevice/avdevice.h>
 #include <libavcodec/avcodec.h>
-#include <libavutil/pixdesc.h>
+#include "mod_avformat.h"
+
+
+/*
+ * TODO:
+ *
+ * ok - Test looping
+ * ok - check audio input/out samplerate/channels
+ * ok - add locking of shared resources
+ * ok - note: one single thread (shared) for audio+video
+ * ok - add audio resampler -> (not yet)
+ *    - test seeking fwd/back
+ *    - proper timestamp sync
+ *    - media-context, use device name or not?
+ */
 
 
 /**
  * @defgroup avformat avformat
  *
- * Video source using FFmpeg/libav libavformat
+ * Video source using FFmpeg libavformat
  *
  *
  * Example config:
  \verbatim
+  audio_source            avformat,/tmp/testfile.mp4
   video_source            avformat,/tmp/testfile.mp4
  \endverbatim
  */
 
 
-struct vidsrc_st {
-	const struct vidsrc *vs;  /* inheritance */
-	pthread_t thread;
-	bool run;
-	AVFormatContext *ic;
-	AVCodecContext *ctx;
-	AVRational time_base;
-	struct vidsz sz;
-	int sindex;
-	vidsrc_frame_h *frameh;
-	void *arg;
-};
-
-
+static struct ausrc *ausrc;
 static struct vidsrc *mod_avf;
 
 
-static void destructor(void *arg)
+static void shared_destructor(void *arg)
 {
-	struct vidsrc_st *st = arg;
+	struct shared *st = arg;
+
+	info(".... avformat: ** shared context destroyed **\n");
 
 	if (st->run) {
 		st->run = false;
 		pthread_join(st->thread, NULL);
 	}
 
-	if (st->ctx && st->ctx->codec)
-		avcodec_close(st->ctx);
+	if (st->au.ctx)
+		avcodec_close(st->au.ctx);
 
-	if (st->ic) {
+	if (st->vid.ctx)
+		avcodec_close(st->vid.ctx);
+
+	if (st->ic)
 		avformat_close_input(&st->ic);
-	}
-}
 
-
-static enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt)
-{
-	switch (pix_fmt) {
-
-	case AV_PIX_FMT_YUV420P:  return VID_FMT_YUV420P;
-	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
-	case AV_PIX_FMT_YUV444P:  return VID_FMT_YUV444P;
-	case AV_PIX_FMT_NV12:     return VID_FMT_NV12;
-	case AV_PIX_FMT_NV21:     return VID_FMT_NV21;
-	default:                  return (enum vidfmt)-1;
-	}
-}
-
-
-static void handle_packet(struct vidsrc_st *st, AVPacket *pkt)
-{
-	AVFrame *frame;
-	struct vidframe vf;
-	struct vidsz sz;
-	unsigned i;
-	int64_t pts;
-	uint64_t timestamp;
-	const AVRational time_base = st->time_base;
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 37, 100)
-	int got_pict;
-#endif
-	int ret;
-
-	frame = av_frame_alloc();
-	if (!frame)
-		return;
-
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 37, 100)
-
-	ret = avcodec_send_packet(st->ctx, pkt);
-	if (ret < 0)
-		goto out;
-
-	ret = avcodec_receive_frame(st->ctx, frame);
-	if (ret < 0)
-		goto out;
-#else
-	ret = avcodec_decode_video2(st->ctx, frame, &got_pict, pkt);
-	if (ret < 0 || !got_pict)
-		goto out;
-#endif
-
-	sz.w = st->ctx->width;
-	sz.h = st->ctx->height;
-
-	/* check if size changed */
-	if (!vidsz_cmp(&sz, &st->sz)) {
-		info("avformat: size changed: %d x %d  ---> %d x %d\n",
-		     st->sz.w, st->sz.h, sz.w, sz.h);
-		st->sz = sz;
-	}
-
-	vf.fmt = avpixfmt_to_vidfmt(frame->format);
-	if (vf.fmt == (enum vidfmt)-1) {
-		warning("avformat: decode: bad pixel format"
-			" (%i) (%s)\n",
-			frame->format,
-			av_get_pix_fmt_name(frame->format));
-		goto out;
-	}
-
-	vf.size = sz;
-	for (i=0; i<4; i++) {
-		vf.data[i]     = frame->data[i];
-		vf.linesize[i] = frame->linesize[i];
-	}
-
-	/* convert timestamp */
-	pts = frame->pts;
-	timestamp = pts * VIDEO_TIMEBASE * time_base.num / time_base.den;
-
-	st->frameh(&vf, timestamp, st->arg);
-
- out:
-	if (frame) {
-#if LIBAVUTIL_VERSION_INT >= ((52<<16)+(20<<8)+100)
-		av_frame_free(&frame);
-#else
-		av_free(frame);
-#endif
-	}
+	mem_deref(st->lock);
 }
 
 
 static void *read_thread(void *data)
 {
-	struct vidsrc_st *st = data;
-	uint64_t now, ts = tmr_jiffies();
+	struct shared *st = data;
+	uint64_t now, offset = tmr_jiffies();
+	double auts = 0, vidts = 0;
 
 	while (st->run) {
+
 		AVPacket pkt;
 		int ret;
 
 		sys_msleep(4);
+
 		now = tmr_jiffies();
 
-		if (ts > now)
-			continue;
+		for (;;) {
+			double xts;
 
-		av_init_packet(&pkt);
+			if (st->au.idx >=0 && st->vid.idx >=0)
+				xts = min(auts, vidts);
+			else if (st->au.idx >=0)
+				xts = auts;
+			else if (st->au.idx >=0)
+				xts = vidts;
+			else
+				break;
 
-		ret = av_read_frame(st->ic, &pkt);
-		if (ret < 0) {
-			debug("avformat: rewind stream (ret=%d)\n", ret);
-			sys_msleep(1000);
-			av_seek_frame(st->ic, -1, 0, 0);
-			continue;
+			if (now < (offset + xts))
+				break;
+
+			av_init_packet(&pkt);
+
+			ret = av_read_frame(st->ic, &pkt);
+			if (ret == (int)AVERROR_EOF) {
+
+				debug("avformat: rewind stream\n");
+
+				sys_msleep(1000);
+
+				ret = av_seek_frame(st->ic, -1, 0,
+						    AVSEEK_FLAG_BACKWARD);
+				if (ret < 0) {
+					info("avformat: seek error (%d)\n",
+					     ret);
+					goto out;
+				}
+
+				offset = tmr_jiffies();
+				break;
+			}
+			else if (ret < 0) {
+				debug("avformat: read error (%d)\n", ret);
+				goto out;
+			}
+
+			if (pkt.stream_index == st->au.idx) {
+
+				if (pkt.pts == AV_NOPTS_VALUE) {
+					warning("no audio pts\n");
+				}
+
+				auts = 1000 * pkt.pts *
+					av_q2d(st->au.time_base);
+
+				avformat_audio_decode(st, &pkt);
+			}
+			else if (pkt.stream_index == st->vid.idx) {
+
+				if (pkt.pts == AV_NOPTS_VALUE) {
+					warning("no video pts\n");
+				}
+
+				vidts = 1000 * pkt.pts *
+					av_q2d(st->vid.time_base);
+
+				avformat_video_decode(st, &pkt);
+			}
+
+			av_packet_unref(&pkt);
 		}
-
-		if (pkt.stream_index != st->sindex)
-			goto out;
-
-		handle_packet(st, &pkt);
-
-		ts += (uint64_t) 1000 * pkt.duration * av_q2d(st->time_base);
-
-	out:
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 12, 100)
-		av_packet_unref(&pkt);
-#else
-		av_free_packet(&pkt);
-#endif
 	}
 
+ out:
 	return NULL;
 }
 
 
-static int alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
-		 struct media_ctx **mctx, struct vidsrc_prm *prm,
-		 const struct vidsz *size, const char *fmt,
-		 const char *dev, vidsrc_frame_h *frameh,
-		 vidsrc_error_h *errorh, void *arg)
+static int open_codec(struct stream *s, const struct AVStream *strm, int i,
+		      AVCodecContext *ctx)
 {
-	struct vidsrc_st *st;
-	bool found_stream = false;
-	uint32_t i;
-	int ret, err = 0;
-	double input_fps = 0;
+	AVCodec *codec;
+	int ret;
 
-	(void)mctx;
-	(void)fmt;
-	(void)errorh;
+	if (s->idx >= 0 || s->ctx)
+		return 0;
 
-	if (!stp || !vs || !prm || !size || !frameh)
-		return EINVAL;
+	codec = avcodec_find_decoder(ctx->codec_id);
+	if (!codec) {
+		info("avformat: can't find codec %i\n",
+		     ctx->codec_id);
+		return ENOENT;
+	}
 
-	debug("avformat: alloc dev='%s'\n", dev);
+	ret = avcodec_open2(ctx, codec, NULL);
+	if (ret < 0) {
+		warning("avformat: error opening codec (%i)\n",
+			ret);
+		return ENOMEM;
+	}
 
-	st = mem_zalloc(sizeof(*st), destructor);
+	s->time_base = strm->time_base;
+	s->ctx = ctx;
+	s->idx = i;
+
+	debug("avformat: '%s' using decoder '%s' (%s)\n",
+	      av_get_media_type_string(ctx->codec_type),
+	      codec->name, codec->long_name);
+
+	return 0;
+}
+
+
+int avformat_shared_alloc(struct shared **shp, const char *dev,
+			  uint32_t srate, int width, int height)
+{
+	struct shared *st;
+	unsigned i;
+	int err;
+	int ret;
+
+	info(".... avformat: shared state (%s)\n", dev);
+
+	st = mem_zalloc(sizeof(*st), shared_destructor);
 	if (!st)
 		return ENOMEM;
 
-	st->vs     = vs;
-	st->sz     = *size;
-	st->frameh = frameh;
-	st->arg    = arg;
+	st->id = "avformat";
+
+	st->au.idx  = -1;
+	st->vid.idx = -1;
+
+	err = lock_alloc(&st->lock);
+	if (err)
+		goto out;
 
 	ret = avformat_open_input(&st->ic, dev, NULL, NULL);
 	if (ret < 0) {
-		warning("avformat: avformat_open_input(%s) failed (ret=%d)\n",
-			dev, ret);
+		warning("avformat: avformat_open_input(%s) failed (ret=%s)\n",
+			dev, av_err2str(ret));
 		err = ENOENT;
 		goto out;
 	}
 
-	ret = avformat_find_stream_info(st->ic, NULL);
-	if (ret < 0) {
-		warning("avformat: %s: no stream info\n", dev);
-		err = ENOENT;
-		goto out;
-	}
+#if 0
+	av_dump_format(st->ic, 0, "", 0);
+#endif
+
+	info("nb_streams: %d\n", st->ic->nb_streams);
 
 	for (i=0; i<st->ic->nb_streams; i++) {
+
 		const struct AVStream *strm = st->ic->streams[i];
 		AVCodecContext *ctx;
-		AVCodec *codec;
-
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
 
 		ctx = avcodec_alloc_context3(NULL);
 		if (!ctx) {
@@ -263,58 +250,23 @@ static int alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 			goto out;
 		}
 
-#else
-		ctx = strm->codec;
-#endif
+		switch (ctx->codec_type) {
 
-		if (ctx->codec_type != AVMEDIA_TYPE_VIDEO)
-			continue;
+		case AVMEDIA_TYPE_AUDIO:
+			err = open_codec(&st->au, strm, i, ctx);
+			if (err)
+				goto out;
+			break;
 
-		debug("avformat: stream %u:  %u x %u "
-		      "  time_base=%d/%d\n",
-		      i, ctx->width, ctx->height,
-		      strm->time_base.num, strm->time_base.den);
+		case AVMEDIA_TYPE_VIDEO:
+			err = open_codec(&st->vid, strm, i, ctx);
+			if (err)
+				goto out;
+			break;
 
-		st->sz.w   = ctx->width;
-		st->sz.h   = ctx->height;
-		st->ctx    = ctx;
-		st->sindex = strm->index;
-		st->time_base = strm->time_base;
-
-		input_fps = av_q2d(strm->avg_frame_rate);
-		if (prm->fps != input_fps) {
-			info("avformat: updating %.2f fps from config"
-			     " to native "
-			     "input material fps %.2f\n",
-			     prm->fps, input_fps);
-
-			prm->fps = input_fps;
+		default:
+			break;
 		}
-
-		codec = avcodec_find_decoder(ctx->codec_id);
-		if (!codec) {
-			warning("avformat: decoder not found (codec_id=%d)\n",
-				ctx->codec_id);
-			err = ENOENT;
-			goto out;
-		}
-
-		ret = avcodec_open2(ctx, codec, NULL);
-		if (ret < 0) {
-			err = ENOENT;
-			goto out;
-		}
-
-		debug("avformat: using decoder '%s' (%s)\n",
-		      codec->name, codec->long_name);
-
-		found_stream = true;
-		break;
-	}
-
-	if (!found_stream) {
-		err = ENOENT;
-		goto out;
 	}
 
 	st->run = true;
@@ -325,40 +277,61 @@ static int alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	}
 
  out:
+
 	if (err)
 		mem_deref(st);
 	else
-		*stp = st;
+		*shp = st;
 
 	return err;
 }
 
 
+void shared_set_audio(struct shared *sh, struct ausrc_st *st)
+{
+	if (!sh)
+		return;
+
+	lock_write_get(sh->lock);
+	sh->ausrc_st = st;
+	lock_rel(sh->lock);
+}
+
+
+void shared_set_video(struct shared *sh, struct vidsrc_st *st)
+{
+	if (!sh)
+		return;
+
+	lock_write_get(sh->lock);
+	sh->vidsrc_st = st;
+	lock_rel(sh->lock);
+}
+
+
 static int module_init(void)
 {
-	/* register all codecs, demux and protocols */
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-	avcodec_register_all();
-#endif
+	int err;
+
+	avformat_network_init();
 	avdevice_register_all();
 
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(53, 13, 0)
-	avformat_network_init();
-#endif
+	err  = ausrc_register(&ausrc, baresip_ausrcl(),
+			      "avformat", avformat_audio_alloc);
 
-	return vidsrc_register(&mod_avf, baresip_vidsrcl(),
-			       "avformat", alloc, NULL);
+	err |= vidsrc_register(&mod_avf, baresip_vidsrcl(),
+			       "avformat", avformat_video_alloc, NULL);
+
+	return err;
 }
 
 
 static int module_close(void)
 {
 	mod_avf = mem_deref(mod_avf);
+	ausrc = mem_deref(ausrc);
 
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(53, 13, 0)
 	avformat_network_deinit();
-#endif
 
 	return 0;
 }
@@ -366,7 +339,7 @@ static int module_close(void)
 
 EXPORT_SYM const struct mod_export DECL_EXPORTS(avformat) = {
 	"avformat",
-	"vidsrc",
+	"avsrc",
 	module_init,
 	module_close
 };

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -12,7 +12,6 @@
 #include <rem.h>
 #include <baresip.h>
 #include <libavformat/avformat.h>
-#include <libavdevice/avdevice.h>
 #include <libavcodec/avcodec.h>
 #include "mod_avformat.h"
 
@@ -313,7 +312,6 @@ static int module_init(void)
 	int err;
 
 	avformat_network_init();
-	avdevice_register_all();
 
 	err  = ausrc_register(&ausrc, baresip_ausrcl(),
 			      "avformat", avformat_audio_alloc);

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -23,8 +23,8 @@ struct shared {
 
 
 int  avformat_shared_alloc(struct shared **shp, const char *dev);
-void shared_set_audio(struct shared *sh, struct ausrc_st *st);
-void shared_set_video(struct shared *sh, struct vidsrc_st *st);
+void avformat_shared_set_audio(struct shared *sh, struct ausrc_st *st);
+void avformat_shared_set_video(struct shared *sh, struct vidsrc_st *st);
 
 
 int  avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -1,0 +1,43 @@
+/**
+ * @file mod_avformat.h  libavformat media-source -- internal interface
+ *
+ * Copyright (C) 2010 - 2020 Creytiv.com
+ */
+
+
+struct shared {
+	const char *id;
+	struct ausrc_st *ausrc_st;    /* pointer */
+	struct vidsrc_st *vidsrc_st;  /* pointer */
+	struct lock *lock;
+	AVFormatContext *ic;
+	pthread_t thread;
+	bool run;
+
+	struct stream {
+		AVRational time_base;
+		AVCodecContext *ctx;
+		int idx;
+	} au, vid;
+};
+
+
+int  avformat_shared_alloc(struct shared **shp, const char *dev,
+			   uint32_t srate, int width, int height);
+void shared_set_audio(struct shared *sh, struct ausrc_st *st);
+void shared_set_video(struct shared *sh, struct vidsrc_st *st);
+
+
+int  avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
+			  struct media_ctx **ctx,
+			  struct ausrc_prm *prm, const char *dev,
+			  ausrc_read_h *readh, ausrc_error_h *errh, void *arg);
+void avformat_audio_decode(struct shared *st, AVPacket *pkt);
+
+
+int  avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
+			  struct media_ctx **ctx, struct vidsrc_prm *prm,
+			  const struct vidsz *size, const char *fmt,
+			  const char *dev, vidsrc_frame_h *frameh,
+			  vidsrc_error_h *errorh, void *arg);
+void avformat_video_decode(struct shared *st, AVPacket *pkt);

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -22,8 +22,7 @@ struct shared {
 };
 
 
-int  avformat_shared_alloc(struct shared **shp, const char *dev,
-			   uint32_t srate, int width, int height);
+int  avformat_shared_alloc(struct shared **shp, const char *dev);
 void shared_set_audio(struct shared *sh, struct ausrc_st *st);
 void shared_set_video(struct shared *sh, struct vidsrc_st *st);
 

--- a/modules/avformat/module.mk
+++ b/modules/avformat/module.mk
@@ -6,6 +6,8 @@
 
 MOD		:= avformat
 $(MOD)_SRCS	+= avformat.c
+$(MOD)_SRCS	+= audio.c
+$(MOD)_SRCS	+= video.c
 $(MOD)_LFLAGS	+= \
 	`pkg-config --libs libavdevice libavformat libavcodec libavutil`
 

--- a/modules/avformat/module.mk
+++ b/modules/avformat/module.mk
@@ -9,6 +9,6 @@ $(MOD)_SRCS	+= avformat.c
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= video.c
 $(MOD)_LFLAGS	+= \
-	`pkg-config --libs libavdevice libavformat libavcodec libavutil`
+	`pkg-config --libs libavformat libavcodec libavutil`
 
 include mk/mod.mk

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -133,7 +133,7 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 		goto out;
 
 #else
-	ret = avcodec_decode_video2(st->ctx, frame, &got_pict, pkt);
+	ret = avcodec_decode_video2(st->vid.ctx, frame, &got_pict, pkt);
 	if (ret < 0 || !got_pict)
 		goto out;
 #endif

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -114,7 +114,7 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 	int got_pict;
 #endif
 
-	if (!st->vid.ctx)
+	if (!st || !st->vid.ctx)
 		return;
 
 	frame = av_frame_alloc();

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -86,7 +86,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 
 	if (st->shared->vid.idx < 0 || !st->shared->vid.ctx) {
 		info("avformat: video: media file has no video stream\n");
-		err = ENOSTR;
+		err = ENOENT;
 		goto out;
 	}
 

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -1,0 +1,161 @@
+/**
+ * @file avformat/video.c  libavformat media-source -- video
+ *
+ * Copyright (C) 2010 - 2020 Creytiv.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <pthread.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/pixdesc.h>
+#include "mod_avformat.h"
+
+
+struct vidsrc_st {
+	const struct vidsrc *vs;  /* base class */
+
+	struct shared *shared;
+	vidsrc_frame_h *frameh;
+	void *arg;
+};
+
+
+static void video_destructor(void *arg)
+{
+	struct vidsrc_st *st = arg;
+
+	shared_set_video(st->shared, NULL);
+	mem_deref(st->shared);
+}
+
+
+static enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt)
+{
+	switch (pix_fmt) {
+
+	case AV_PIX_FMT_YUV420P:  return VID_FMT_YUV420P;
+	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
+	case AV_PIX_FMT_YUV444P:  return VID_FMT_YUV444P;
+	case AV_PIX_FMT_NV12:     return VID_FMT_NV12;
+	case AV_PIX_FMT_NV21:     return VID_FMT_NV21;
+	case AV_PIX_FMT_UYVY422:  return VID_FMT_UYVY422;
+	default:                  return (enum vidfmt)-1;
+	}
+}
+
+
+int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
+			 struct media_ctx **ctx, struct vidsrc_prm *prm,
+			 const struct vidsz *size, const char *fmt,
+			 const char *dev, vidsrc_frame_h *frameh,
+			 vidsrc_error_h *errorh, void *arg)
+{
+	struct vidsrc_st *st;
+	int err = 0;
+
+	(void)fmt;
+	(void)errorh;
+
+	if (!stp || !vs || !prm || !size || !frameh)
+		return EINVAL;
+
+	debug("avformat: video: alloc dev='%s'\n", dev);
+
+	st = mem_zalloc(sizeof(*st), video_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->vs     = vs;
+	st->frameh = frameh;
+	st->arg    = arg;
+
+	if (ctx && *ctx && (*ctx)->id && !strcmp((*ctx)->id, "avformat")) {
+		st->shared = mem_ref(*ctx);
+	}
+	else {
+		err = avformat_shared_alloc(&st->shared, dev, 0,
+					    size->w, size->h);
+		if (err)
+			goto out;
+
+		if (ctx)
+			*ctx = (struct media_ctx *)st->shared;
+	}
+
+	if (st->shared->vid.idx < 0 || !st->shared->vid.ctx) {
+		info("avformat: video: media file has no video stream\n");
+		err = ENOSTR;
+		goto out;
+	}
+
+	shared_set_video(st->shared, st);
+
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}
+
+
+void avformat_video_decode(struct shared *st, AVPacket *pkt)
+{
+	const AVRational tb = st->vid.time_base;
+	struct vidframe vf;
+	AVFrame *frame;
+	uint64_t timestamp;
+	unsigned i;
+	int ret;
+
+	if (!st->vid.ctx)
+		return;
+
+	frame = av_frame_alloc();
+	if (!frame)
+		return;
+
+	ret = avcodec_send_packet(st->vid.ctx, pkt);
+	if (ret < 0)
+		goto out;
+
+	ret = avcodec_receive_frame(st->vid.ctx, frame);
+	if (ret < 0)
+		goto out;
+
+	vf.fmt = avpixfmt_to_vidfmt(frame->format);
+	if (vf.fmt == (enum vidfmt)-1) {
+		warning("avformat: decode: bad pixel format"
+			" (%i) (%s)\n",
+			frame->format,
+			av_get_pix_fmt_name(frame->format));
+		goto out;
+	}
+
+	vf.size.w = st->vid.ctx->width;
+	vf.size.h = st->vid.ctx->height;
+
+	for (i=0; i<4; i++) {
+		vf.data[i]     = frame->data[i];
+		vf.linesize[i] = frame->linesize[i];
+	}
+
+	/* convert timestamp */
+	timestamp = frame->pts * VIDEO_TIMEBASE * tb.num / tb.den;
+
+	lock_read_get(st->lock);
+
+	if (st->vidsrc_st && st->vidsrc_st->frameh)
+		st->vidsrc_st->frameh(&vf, timestamp, st->vidsrc_st->arg);
+
+	lock_rel(st->lock);
+
+ out:
+	if (frame)
+		av_frame_free(&frame);
+}

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -76,8 +76,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 		st->shared = mem_ref(*ctx);
 	}
 	else {
-		err = avformat_shared_alloc(&st->shared, dev, 0,
-					    size->w, size->h);
+		err = avformat_shared_alloc(&st->shared, dev);
 		if (err)
 			goto out;
 

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -27,7 +27,7 @@ static void video_destructor(void *arg)
 {
 	struct vidsrc_st *st = arg;
 
-	shared_set_video(st->shared, NULL);
+	avformat_shared_set_video(st->shared, NULL);
 	mem_deref(st->shared);
 }
 
@@ -90,8 +90,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 		goto out;
 	}
 
-	shared_set_video(st->shared, st);
-
+	avformat_shared_set_video(st->shared, st);
 
  out:
 	if (err)


### PR DESCRIPTION
This PR adds support for audio in the avformat.so module

You can use it to read the audio track from an MP4 file:

audio_source    avformat,foo.mp4
video_source    avformat,foo.mp4

Any avformat backend is supported, except avdevice

```
Compile Testing:


Platform:     ffmpeg:          Status:
--------      ------           ------

Debian 9      3.2.12-1~deb9u1  OK
Debian 10     4.1.4-1~deb10u1  OK
Ubuntu 16.04  2.8.15-0ubuntu0  OK
OSX 10.12     4.2.1            OK
```

