### PR TITLE
echo: fix flushing session

### DIFF
--- a/modules/echo/echo.c
+++ b/modules/echo/echo.c
@@ -26,11 +26,9 @@ static void destructor(void *arg)
 {
 	struct session *sess = arg;
 
-	debug("echo: session destroyed (in=%p)\n",
-			sess->call_in);
+	debug("echo: session destroyed\n");
 
 	list_unlink(&sess->le);
-	mem_deref(sess->call_in);
 }
 
 
@@ -44,6 +42,7 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 	case CALL_EVENT_CLOSED:
 		debug("echo: CALL_CLOSED: %s\n", str);
+		mem_deref(sess->call_in);
 		mem_deref(sess);
 		break;
 


### PR DESCRIPTION
```
ua: sip-stack exit
ua exited -- stopping main runloop
module: unloading app vidloop
module: unloading app menu
menu: close (redial current_attempts=0) 
module: unloading app echo
echo: module closing..
echo: flushing 1 sessions
echo: session destroyed (in=0x55c9fb8bcbc0)
mem: mem_deref: magic check failed 0xb5b5b5b5 (0x55c9fb8bcbc0)
Trace/breakpoint trap (core dumped)
```