### PR TITLE
prompt password only if auth_user is set and auth_pass is not

### DIFF
--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -144,8 +144,9 @@ static int line_handler(const struct pl *addr, void *arg)
 		}
 	}
 
-	/* optional password prompt */
-	if (!str_isset(account_auth_pass(acc))) {
+	/* prompt password if auth_user is set, but auth_pass is not  */
+	if (str_isset(account_auth_user(acc)) &&
+	    !str_isset(account_auth_pass(acc))) {
 		char *pass = NULL;
 
 		(void)re_printf("Please enter password for %s: ",


### PR DESCRIPTION
There are use cases where account does not need to authenticate itself when sending SIP requests, for example, when it is only used to call some public service URIs.

So far I have not figured out how to create an account without auth_user and auth_pass so that password is not prompted when account module is loaded.  

This pull requests solves the issue by causing password prompting only if auth_user is set and auth_pass is not set.  Better solutions are, of course, welcome .