### PR TITLE
Ausrc add auframe

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -38,6 +38,11 @@ struct vidframe;
 struct vidrect;
 struct vidsz;
 
+struct auframe {
+	void *sampv;
+	size_t sampc;
+};
+
 
 /*
  * Account
@@ -411,7 +416,7 @@ struct ausrc_prm {
 	int        fmt;         /**< Sample format (enum aufmt) */
 };
 
-typedef void (ausrc_read_h)(const void *sampv, size_t sampc, void *arg);
+typedef void (ausrc_read_h)(struct auframe *af, void *arg);
 typedef void (ausrc_error_h)(int err, const char *str, void *arg);
 
 typedef int  (ausrc_alloc_h)(struct ausrc_st **stp, const struct ausrc *ausrc,

--- a/modules/alsa/alsa_src.c
+++ b/modules/alsa/alsa_src.c
@@ -67,7 +67,7 @@ static void *read_thread(void *arg)
 	}
 
 	while (st->run) {
-		size_t sampc;
+		struct auframe af;
 		long n;
 
 		n = snd_pcm_readi(st->read, st->sampv, num_frames);
@@ -79,9 +79,10 @@ static void *read_thread(void *arg)
 			continue;
 		}
 
-		sampc = n * st->prm.ch;
+		af.sampv = st->sampv;
+		af.sampc = n * st->prm.ch;
 
-		st->rh(st->sampv, sampc, st->arg);
+		st->rh(&af, st->arg);
 	}
 
  out:

--- a/modules/aubridge/device.c
+++ b/modules/aubridge/device.c
@@ -101,7 +101,11 @@ static void *device_thread(void *arg)
 		}
 
 		if (dev->ausrc->rh) {
-			dev->ausrc->rh(sampv_in, sampc_in, dev->ausrc->arg);
+			struct auframe af = {
+				.sampv = sampv_in,
+				.sampc = sampc_in
+			};
+			dev->ausrc->rh(&af, dev->ausrc->arg);
 		}
 
 		ts += PTIME;

--- a/modules/audiounit/recorder.c
+++ b/modules/audiounit/recorder.c
@@ -103,6 +103,8 @@ static OSStatus input_callback(void *inRefCon,
 	}
 
 	while (1) {
+		struct auframe af;
+
 		err = get_nb_frames(st->buf, &nb_frames);
 		if (err)
 			return kAudioUnitErr_InvalidParameter;
@@ -129,9 +131,12 @@ static OSStatus input_callback(void *inRefCon,
 			return ret;
 		}
 
-		rh(abl_conv.mBuffers[0].mData,
-		   abl_conv.mBuffers[0].mDataByteSize/st->sampsz, arg);
+		af.sampv = abl_conv.mBuffers[0].mData;
+		af.sampc = abl_conv.mBuffers[0].mDataByteSize/st->sampsz;
+
+		rh(&af, arg);
 	}
+
 	return noErr;
 }
 

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -70,6 +70,11 @@ static void *play_thread(void *arg)
 
 	while (st->run) {
 
+		struct auframe af = {
+			.sampv = sampv,
+			.sampc = st->sampc
+		};
+
 		sys_msleep(4);
 
 		now = tmr_jiffies();
@@ -79,7 +84,7 @@ static void *play_thread(void *arg)
 
 		aubuf_read_samp(st->aubuf, sampv, st->sampc);
 
-		st->rh(sampv, st->sampc, st->arg);
+		st->rh(&af, st->arg);
 
 		ts += st->ptime;
 	}

--- a/modules/auloop/auloop.c
+++ b/modules/auloop/auloop.c
@@ -196,16 +196,16 @@ static void tmr_handler(void *arg)
 }
 
 
-static void src_read_handler(const void *sampv, size_t sampc, void *arg)
+static void src_read_handler(struct auframe *af, void *arg)
 {
 	struct audio_loop *al = arg;
-	size_t num_bytes = sampc * aufmt_sample_size(al->fmt);
+	size_t num_bytes = af->sampc * aufmt_sample_size(al->fmt);
 	struct stats *stats = &al->stats_src;
 	int err;
 
 	lock_write_get(al->lock);
 
-	stats->n_samp   += sampc;
+	stats->n_samp   += af->sampc;
 	stats->n_frames += 1;
 
 	if (aubuf_cur_size(al->aubuf) >= al->aubuf_maxsz) {
@@ -214,7 +214,7 @@ static void src_read_handler(const void *sampv, size_t sampc, void *arg)
 
 	lock_rel(al->lock);
 
-	err = aubuf_write(al->aubuf, sampv, num_bytes);
+	err = aubuf_write(al->aubuf, af->sampv, num_bytes);
 	if (err) {
 		warning("auloop: aubuf_write: %m\n", err);
 	}

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -160,9 +160,13 @@ void avformat_audio_decode(struct shared *st, AVPacket *pkt)
 	lock_read_get(st->lock);
 
 	if (st->ausrc_st && st->ausrc_st->readh) {
-		st->ausrc_st->readh(frame.data[0],
-				    frame.nb_samples * frame.channels,
-				    st->ausrc_st->arg);
+
+		struct auframe af = {
+			.sampv = frame.data[0],
+			.sampc = frame.nb_samples * frame.channels
+		};
+
+		st->ausrc_st->readh(&af, st->ausrc_st->arg);
 	}
 
 	lock_rel(st->lock);

--- a/modules/coreaudio/recorder.c
+++ b/modules/coreaudio/recorder.c
@@ -57,6 +57,7 @@ static void record_handler(void *userData, AudioQueueRef inQ,
 			   const AudioStreamPacketDescription *inPacketDesc)
 {
 	struct ausrc_st *st = userData;
+	struct auframe af;
 	ausrc_read_h *rh;
 	void *arg;
 	(void)inStartTime;
@@ -71,7 +72,10 @@ static void record_handler(void *userData, AudioQueueRef inQ,
 	if (!rh)
 		return;
 
-	rh(inQB->mAudioData, inQB->mAudioDataByteSize/st->sampsz, arg);
+	af.sampv = inQB->mAudioData;
+	af.sampc = inQB->mAudioDataByteSize/st->sampsz;
+
+	rh(&af, arg);
 
 	AudioQueueEnqueueBuffer(inQ, inQB, 0, NULL);
 }

--- a/modules/gst/gst.c
+++ b/modules/gst/gst.c
@@ -175,6 +175,10 @@ static void format_check(struct ausrc_st *st, GstStructure *s)
 static void play_packet(struct ausrc_st *st)
 {
 	int16_t buf[st->sampc];
+	struct auframe af = {
+		.sampv = buf,
+		.sampc = st->sampc
+	};
 
 	/* timed read from audio-buffer */
 	if (aubuf_get_samp(st->aubuf, st->prm.ptime, buf, st->sampc))
@@ -182,7 +186,7 @@ static void play_packet(struct ausrc_st *st)
 
 	/* call read handler */
 	if (st->rh)
-		st->rh(buf, st->sampc, st->arg);
+		st->rh(&af, st->arg);
 }
 
 

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -29,6 +29,7 @@ struct ausrc_st {
 static int process_handler(jack_nframes_t nframes, void *arg)
 {
 	struct ausrc_st *st = arg;
+	struct auframe af;
 	size_t sampc = nframes * st->prm.ch;
 	size_t ch, j;
 
@@ -47,8 +48,11 @@ static int process_handler(jack_nframes_t nframes, void *arg)
 		}
 	}
 
+	af.sampv = st->sampv;
+	af.sampc = sampc;
+
 	/* 1. read data from app (signed 16-bit) interleaved */
-	st->rh(st->sampv, sampc, st->arg);
+	st->rh(&af, st->arg);
 
 	return 0;
 }

--- a/modules/opensles/recorder.c
+++ b/modules/opensles/recorder.c
@@ -55,10 +55,13 @@ static void ausrc_destructor(void *arg)
 static void bqRecorderCallback(SLAndroidSimpleBufferQueueItf bq, void *context)
 {
 	struct ausrc_st *st = context;
-
+	struct auframe af = {
+		.sampv = st->sampv[st->bufferId],
+		.sampc = st->sampc
+	};
 	(void)bq;
 
-	st->rh(st->sampv[st->bufferId], st->sampc, st->arg);
+	st->rh(&af, st->arg);
 
 	st->bufferId = ( st->bufferId + 1 ) % N_REC_QUEUE_BUFFERS;
 

--- a/modules/oss/oss.c
+++ b/modules/oss/oss.c
@@ -180,6 +180,7 @@ static void ausrc_destructor(void *arg)
 static void *record_thread(void *arg)
 {
 	struct ausrc_st *st = arg;
+	struct auframe af;
 	int n;
 
 	while (st->run) {
@@ -188,7 +189,10 @@ static void *record_thread(void *arg)
 		if (n <= 0)
 			continue;
 
-		st->rh(st->sampv, n/2, st->arg);
+		af.sampv = st->sampv;
+		af.sampc = n/2;
+
+		st->rh(&af, st->arg);
 	}
 
 	return NULL;

--- a/modules/portaudio/portaudio.c
+++ b/modules/portaudio/portaudio.c
@@ -59,6 +59,7 @@ static int read_callback(const void *inputBuffer, void *outputBuffer,
 			 PaStreamCallbackFlags statusFlags, void *userData)
 {
 	struct ausrc_st *st = userData;
+	struct auframe af;
 	size_t sampc;
 
 	(void)outputBuffer;
@@ -70,7 +71,10 @@ static int read_callback(const void *inputBuffer, void *outputBuffer,
 
 	sampc = frameCount * st->ch;
 
-	st->rh(inputBuffer, sampc, st->arg);
+	af.sampv = (void *)inputBuffer;
+	af.sampc = sampc;
+
+	st->rh(&af, st->arg);
 
 	return paContinue;
 }

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -64,6 +64,11 @@ static void *read_thread(void *arg)
 
 	while (st->run) {
 
+		struct auframe af = {
+			.sampv = st->sampv,
+			.sampc = st->sampc
+		};
+
 		ret = pa_simple_read(st->s, st->sampv, num_bytes, &pa_error);
 		if (ret < 0) {
 			warning("pulse: pa_simple_read error (%s)\n",
@@ -92,7 +97,7 @@ static void *read_thread(void *arg)
 			}
 		}
 
-		st->rh(st->sampv, st->sampc, st->arg);
+		st->rh(&af, st->arg);
 	}
 
 	return NULL;

--- a/modules/rst/audio.c
+++ b/modules/rst/audio.c
@@ -69,6 +69,11 @@ static void *play_thread(void *arg)
 
 	while (st->run) {
 
+		struct auframe af = {
+			.sampv = sampv,
+			.sampc = st->sampc
+		};
+
 		sys_msleep(4);
 
 		now = tmr_jiffies();
@@ -84,7 +89,7 @@ static void *play_thread(void *arg)
 
 		aubuf_read(st->aubuf, sampv, num_bytes);
 
-		st->rh(sampv, st->sampc, st->arg);
+		st->rh(&af, st->arg);
 
 		ts += st->ptime;
 	}

--- a/modules/sndio/sndio.c
+++ b/modules/sndio/sndio.c
@@ -78,8 +78,13 @@ static void *read_thread(void *arg)
 	}
 
 	while (st->run) {
+		struct auframe af;
 		size_t n = sio_read(st->hdl, st->sampv, st->sampc*2);
-		st->rh(st->sampv, n/2, st->arg);
+
+		af.sampv = st->sampv;
+		af.sampc = n/2;
+
+		st->rh(&af, st->arg);
 	}
 
  out:

--- a/modules/winwave/src.c
+++ b/modules/winwave/src.c
@@ -85,6 +85,7 @@ static void CALLBACK waveInCallback(HWAVEOUT hwo,
 {
 	struct ausrc_st *st = (struct ausrc_st *)dwInstance;
 	WAVEHDR *wh = (WAVEHDR *)dwParam1;
+	struct auframe af;
 
 	(void)hwo;
 	(void)dwParam2;
@@ -106,8 +107,10 @@ static void CALLBACK waveInCallback(HWAVEOUT hwo,
 		if (st->inuse < (READ_BUFFERS-1))
 			add_wave_in(st);
 
-		st->rh((void *)wh->lpData, wh->dwBytesRecorded/st->sampsz,
-		       st->arg);
+		af.sampv = (void *)wh->lpData;
+		af.sampc = wh->dwBytesRecorded/st->sampsz;
+
+		st->rh(&af, st->arg);
 
 		waveInUnprepareHeader(st->wavein, wh, sizeof(*wh));
 		st->inuse--;

--- a/src/audio.c
+++ b/src/audio.c
@@ -642,14 +642,14 @@ static void auplay_write_handler(void *sampv, size_t sampc, void *arg)
  * @param sampc  Number of samples in buffer
  * @param arg    Handler argument
  */
-static void ausrc_read_handler(const void *sampv, size_t sampc, void *arg)
+static void ausrc_read_handler(struct auframe *af, void *arg)
 {
 	struct audio *a = arg;
 	struct autx *tx = &a->tx;
-	size_t num_bytes = sampc * aufmt_sample_size(tx->src_fmt);
+	size_t num_bytes = af->sampc * aufmt_sample_size(tx->src_fmt);
 
 	if (tx->muted)
-		memset((void *)sampv, 0, num_bytes);
+		memset((void *)af->sampv, 0, num_bytes);
 
 	if (aubuf_cur_size(tx->aubuf) >= tx->aubuf_maxsz) {
 
@@ -659,7 +659,7 @@ static void ausrc_read_handler(const void *sampv, size_t sampc, void *arg)
 		      tx->stats.aubuf_overrun);
 	}
 
-	(void)aubuf_write(tx->aubuf, sampv, num_bytes);
+	(void)aubuf_write(tx->aubuf, af->sampv, num_bytes);
 
 	tx->aubuf_started = true;
 

--- a/test/mock/mock_ausrc.c
+++ b/test/mock/mock_ausrc.c
@@ -24,11 +24,15 @@ struct ausrc_st {
 static void tmr_handler(void *arg)
 {
 	struct ausrc_st *st = arg;
+	struct auframe af = {
+		.sampv = st->sampv,
+		.sampc = st->sampc
+	};
 
 	tmr_start(&st->tmr, st->prm.ptime, tmr_handler, st);
 
 	if (st->rh)
-		st->rh(st->sampv, st->sampc, st->arg);
+		st->rh(&af, st->arg);
 }
 
 


### PR DESCRIPTION
- Add auframe type
- Change ausrc api to use auframe

The purpose is to add a more flexible type, and add more members
to struct auframe later, such as sample format, sample rate, channels

Tested modules:

- [x] alsa
- [x] aubridge
- [x] audiounit
- [x] aufile
- [x] avformat
- [x] coreaudio
- [x] gst
- [ ] i2s
- [x] jack
- [x] opensles
- [x] oss
- [x] portaudio
- [x] pulse
- [x] rst
- [x] sndio
- [x] winwave