### PR TITLE
Added account_luri API function

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -73,6 +73,7 @@ int account_auth(const struct account *acc, char **username, char **password,
 struct list *account_aucodecl(const struct account *acc);
 struct list *account_vidcodecl(const struct account *acc);
 struct sip_addr *account_laddr(const struct account *acc);
+struct uri *account_luri(const struct account *acc);
 uint32_t account_regint(const struct account *acc);
 uint32_t account_pubint(const struct account *acc);
 uint32_t account_ptime(const struct account *acc);

--- a/src/account.c
+++ b/src/account.c
@@ -865,6 +865,19 @@ struct sip_addr *account_laddr(const struct account *acc)
 
 
 /**
+ * Get the decoded AOR URI of an account
+ *
+ * @param acc User-Agent account
+ *
+ * @return Decoded URI
+ */
+struct uri *account_luri(const struct account *acc)
+{
+	return acc ? (struct uri *)&acc->luri : NULL;
+}
+
+
+/**
  * Get the Registration interval of an account
  *
  * @param acc User-Agent account


### PR DESCRIPTION
Needed to get full AoR URI that includes not just username@domain:port, but also parameters, such as ;transport.