### PR TITLE
alsa: mark thread control variables volatile

### DIFF
--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -20,7 +20,7 @@
 struct auplay_st {
 	const struct auplay *ap;  /* pointer to base-class (inheritance) */
 	pthread_t thread;
-	bool run;
+	volatile bool run;
 	snd_pcm_t *write;
 	void *sampv;
 	size_t sampc;

--- a/modules/alsa/alsa_src.c
+++ b/modules/alsa/alsa_src.c
@@ -20,7 +20,7 @@
 struct ausrc_st {
 	const struct ausrc *as;  /* pointer to base-class (inheritance) */
 	pthread_t thread;
-	bool run;
+	volatile bool run;
 	snd_pcm_t *read;
 	void *sampv;
 	size_t sampc;


### PR DESCRIPTION
This prevents compilers to optimize them away.

gcc -O2 now creates different code. I'm not sure whether the old output was
actually broken. The point is, that without volatile some compilers
might produce broken code.

Signed-off-by: Harald Geyer <harald@ccbib.org>

I stumbled upon this while looking why baresip sometimes hangs in auplay_destructor(). The behaviour I see still doesn't make sense to me, but I guess this is a step forward in getting rid of hard to reproduce bugs.