### PR TITLE
auframe: add timestamp

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -22,6 +22,11 @@ extern "C" {
 
 
 /*
+ * Clock-rate for audio timestamp
+ */
+#define AUDIO_TIMEBASE 1000000U
+
+/*
  * Clock-rate for video timestamp
  */
 #define VIDEO_TIMEBASE 1000000U
@@ -106,6 +111,7 @@ struct auframe {
 	int fmt;       /**< Sample format (enum aufmt)        */
 	void *sampv;   /**< Audio samples (must be mem_ref'd) */
 	size_t sampc;  /**< Total number of audio samples     */
+	uint64_t timestamp;  /**< Timestamp in AUDIO_TIMEBASE units */
 };
 
 void   auframe_init(struct auframe *af, int fmt, void *sampv, size_t sampc);

--- a/modules/alsa/alsa_src.c
+++ b/modules/alsa/alsa_src.c
@@ -53,6 +53,7 @@ static void ausrc_destructor(void *arg)
 static void *read_thread(void *arg)
 {
 	struct ausrc_st *st = arg;
+	uint64_t frames = 0;
 	int num_frames;
 	int err;
 
@@ -82,6 +83,9 @@ static void *read_thread(void *arg)
 		af.fmt   = st->prm.fmt;
 		af.sampv = st->sampv;
 		af.sampc = n * st->prm.ch;
+		af.timestamp = frames * AUDIO_TIMEBASE / st->prm.srate;
+
+		frames += n;
 
 		st->rh(&af, st->arg);
 	}

--- a/modules/aubridge/device.c
+++ b/modules/aubridge/device.c
@@ -104,7 +104,8 @@ static void *device_thread(void *arg)
 			struct auframe af = {
 				.fmt   = dev->ausrc->prm.fmt,
 				.sampv = sampv_in,
-				.sampc = sampc_in
+				.sampc = sampc_in,
+				.timestamp = ts * 1000
 			};
 			dev->ausrc->rh(&af, dev->ausrc->arg);
 		}

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -74,7 +74,8 @@ static void *play_thread(void *arg)
 		struct auframe af = {
 			.fmt   = AUFMT_S16LE,
 			.sampv = sampv,
-			.sampc = st->sampc
+			.sampc = st->sampc,
+			.timestamp = ts * 1000
 		};
 
 		sys_msleep(4);

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -155,6 +155,7 @@ void avformat_audio_decode(struct shared *st, AVPacket *pkt)
 
 	if (st->ausrc_st && st->ausrc_st->readh) {
 
+		const AVRational tb = st->au.time_base;
 		struct auframe af;
 
 		frame.channel_layout =
@@ -177,6 +178,7 @@ void avformat_audio_decode(struct shared *st, AVPacket *pkt)
 		af.fmt   = st->ausrc_st->prm.fmt;
 		af.sampv = frame2.data[0];
 		af.sampc = frame2.nb_samples * frame2.channels;
+		af.timestamp = frame.pts * AUDIO_TIMEBASE * tb.num / tb.den;
 
 		st->ausrc_st->readh(&af, st->ausrc_st->arg);
 	}

--- a/modules/coreaudio/recorder.c
+++ b/modules/coreaudio/recorder.c
@@ -17,9 +17,11 @@
 
 struct ausrc_st {
 	const struct ausrc *as;      /* inheritance */
+
 	AudioQueueRef queue;
 	AudioQueueBufferRef buf[BUFC];
 	pthread_mutex_t mutex;
+	struct ausrc_prm prm;
 	uint32_t sampsz;
 	int fmt;
 	ausrc_read_h *rh;
@@ -76,6 +78,7 @@ static void record_handler(void *userData, AudioQueueRef inQ,
 	af.fmt   = st->fmt;
 	af.sampv = inQB->mAudioData;
 	af.sampc = inQB->mAudioDataByteSize/st->sampsz;
+	af.timestamp = AUDIO_TIMEBASE*inStartTime->mSampleTime / st->prm.srate;
 
 	rh(&af, arg);
 
@@ -117,6 +120,7 @@ int coreaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	sampc = prm->srate * prm->ch * prm->ptime / 1000;
 	bytc  = sampc * st->sampsz;
 	st->fmt = prm->fmt;
+	st->prm = *prm;
 
 	err = pthread_mutex_init(&st->mutex, NULL);
 	if (err)

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -34,7 +34,7 @@ static int process_handler(jack_nframes_t nframes, void *arg)
 	size_t ch, j;
 	uint64_t ts;
 
-	ts = jack_frame_time(st->client) * AUDIO_TIMEBASE / st->prm.srate;
+	ts = jack_frames_to_time(st->client, jack_last_frame_time(st->client));
 
 	/* 2. convert from 16-bit to float and copy to Jack */
 

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -32,6 +32,9 @@ static int process_handler(jack_nframes_t nframes, void *arg)
 	struct auframe af;
 	size_t sampc = nframes * st->prm.ch;
 	size_t ch, j;
+	uint64_t ts;
+
+	ts = jack_frame_time(st->client) * AUDIO_TIMEBASE / st->prm.srate;
 
 	/* 2. convert from 16-bit to float and copy to Jack */
 
@@ -51,6 +54,7 @@ static int process_handler(jack_nframes_t nframes, void *arg)
 	af.fmt   = st->prm.fmt;
 	af.sampv = st->sampv;
 	af.sampc = sampc;
+	af.timestamp = ts;
 
 	/* 1. read data from app (signed 16-bit) interleaved */
 	st->rh(&af, st->arg);

--- a/modules/portaudio/portaudio.c
+++ b/modules/portaudio/portaudio.c
@@ -75,6 +75,7 @@ static int read_callback(const void *inputBuffer, void *outputBuffer,
 	af.fmt   = st->fmt;
 	af.sampv = (void *)inputBuffer;
 	af.sampc = sampc;
+	af.timestamp = Pa_GetStreamTime(st->stream_rd) * AUDIO_TIMEBASE;
 
 	st->rh(&af, st->arg);
 

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -16,6 +16,7 @@
 struct ausrc_st {
 	const struct ausrc *as;      /* inheritance */
 
+	struct ausrc_prm prm;
 	pa_simple *s;
 	pthread_t thread;
 	bool run;
@@ -55,6 +56,7 @@ static void *read_thread(void *arg)
 	uint64_t now, last_read, diff;
 	unsigned dropped = 0;
 	bool init = true;
+	size_t sampc = 0;
 
 	if (pa_simple_flush(st->s, &pa_error)) {
 		warning("pulse: pa_simple_flush error (%s)\n",
@@ -68,7 +70,9 @@ static void *read_thread(void *arg)
 		struct auframe af = {
 			.fmt   = st->fmt,
 			.sampv = st->sampv,
-			.sampc = st->sampc
+			.sampc = st->sampc,
+			.timestamp = sampc * AUDIO_TIMEBASE
+			             / (st->prm.srate * st->prm.ch)
 		};
 
 		ret = pa_simple_read(st->s, st->sampv, num_bytes, &pa_error);
@@ -98,6 +102,8 @@ static void *read_thread(void *arg)
 					      "the recording\n", dropped);
 			}
 		}
+
+		sampc += st->sampc;
 
 		st->rh(&af, st->arg);
 	}
@@ -150,6 +156,7 @@ int pulse_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	st->sampsz = aufmt_sample_size(prm->fmt);
 	st->ptime = prm->ptime;
 	st->fmt = prm->fmt;
+	st->prm = *prm;
 
 	st->sampv = mem_alloc(st->sampsz * st->sampc, NULL);
 	if (!st->sampv) {

--- a/modules/rst/audio.c
+++ b/modules/rst/audio.c
@@ -73,7 +73,8 @@ static void *play_thread(void *arg)
 		struct auframe af = {
 			.fmt   = st->fmt,
 			.sampv = sampv,
-			.sampc = st->sampc
+			.sampc = st->sampc,
+			.timestamp = ts * 1000
 		};
 
 		sys_msleep(4);

--- a/modules/winwave/src.c
+++ b/modules/winwave/src.c
@@ -87,6 +87,7 @@ static void CALLBACK waveInCallback(HWAVEOUT hwo,
 	struct ausrc_st *st = (struct ausrc_st *)dwInstance;
 	WAVEHDR *wh = (WAVEHDR *)dwParam1;
 	struct auframe af;
+	MMTIME mmtime;
 
 	(void)hwo;
 	(void)dwParam2;
@@ -108,9 +109,12 @@ static void CALLBACK waveInCallback(HWAVEOUT hwo,
 		if (st->inuse < (READ_BUFFERS-1))
 			add_wave_in(st);
 
+		waveInGetPosition(st->wavein, &mmtime, sizeof(mmtime));
+
 		af.fmt   = st->fmt;
 		af.sampv = (void *)wh->lpData;
 		af.sampc = wh->dwBytesRecorded/st->sampsz;
+		af.timestamp = mmtime.u.ms * 1000;
 
 		st->rh(&af, st->arg);
 

--- a/test/mock/mock_ausrc.c
+++ b/test/mock/mock_ausrc.c
@@ -36,7 +36,8 @@ static void tmr_handler(void *arg)
 	struct auframe af = {
 		.fmt   = st->prm.fmt,
 		.sampv = st->sampv,
-		.sampc = st->sampc
+		.sampc = st->sampc,
+		.timestamp = tmr_jiffies_usec()
 	};
 
 	tmr_start(&st->tmr, st->prm.ptime, tmr_handler, st);


### PR DESCRIPTION
Add timestamp to audio frame. The clock-rate of the timestamp is in microseconds:

`#define AUDIO_TIMEBASE 1000000U`

Updated audio source modules:

* [x] alsa
* [x] aubridge
* [x] audiounit
* [x] aufile
* [x] avformat
* [x] coreaudio
* [ ] gst
* [ ] i2s
* [x] jack
* [ ] opensles
* [x] oss
* [x] portaudio
* [x] pulse
* [x] rst
* [ ] sndio
* [x] winwave
