### PR TITLE
avformat: enhanced avformat_shared_alloc() function

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -84,11 +84,16 @@ USE_AVCODEC := $(shell [ -f $(SYSROOT)/include/libavcodec/avcodec.h ] || \
 	[ -f $(SYSROOT)/local/include/libavcodec/avcodec.h ] || \
 	[ -f $(SYSROOT)/include/$(MACHINE)/libavcodec/avcodec.h ] || \
 	[ -f $(SYSROOT_ALT)/include/libavcodec/avcodec.h ] && echo "yes")
-USE_AVFORMAT := $(shell [ -f $(SYSROOT)/include/libavformat/avformat.h ] || \
+USE_AVFORMAT := $(shell ([ -f $(SYSROOT)/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT_LOCAL)/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT)/local/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT)/include/$(MACHINE)/libavformat/avformat.h ] || \
-	[ -f $(SYSROOT_ALT)/include/libavformat/avformat.h ] && echo "yes")
+	[ -f $(SYSROOT_ALT)/include/libavformat/avformat.h ]) &&
+	([ -f $(SYSROOT)/include/libavformat/avdevice.h ] || \
+	[ -f $(SYSROOT_LOCAL)/include/libavdevice/avdevice.h ] || \
+	[ -f $(SYSROOT)/local/include/libavdevice/avdevice.h ] || \
+	[ -f $(SYSROOT)/include/$(MACHINE)/libavdevice/avdevice.h ] || \
+	[ -f $(SYSROOT_ALT)/include/libavdevice/avdevice.h ]) && echo "yes")
 USE_CAIRO  := $(shell [ -f $(SYSROOT)/include/cairo/cairo.h ] || \
 	[ -f $(SYSROOT)/local/include/cairo/cairo.h ] || \
 	[ -f $(SYSROOT_ALT)/include/cairo/cairo.h ] && echo "yes")

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -88,7 +88,7 @@ USE_AVFORMAT := $(shell ([ -f $(SYSROOT)/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT_LOCAL)/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT)/local/include/libavformat/avformat.h ] || \
 	[ -f $(SYSROOT)/include/$(MACHINE)/libavformat/avformat.h ] || \
-	[ -f $(SYSROOT_ALT)/include/libavformat/avformat.h ]) &&
+	[ -f $(SYSROOT_ALT)/include/libavformat/avformat.h ]) && \
 	([ -f $(SYSROOT)/include/libavformat/avdevice.h ] || \
 	[ -f $(SYSROOT_LOCAL)/include/libavdevice/avdevice.h ] || \
 	[ -f $(SYSROOT)/local/include/libavdevice/avdevice.h ] || \

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -79,7 +79,8 @@ int avformat_audio_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		st->shared = mem_ref(*ctx);
 	}
 	else {
-		err = avformat_shared_alloc(&st->shared, dev);
+		err = avformat_shared_alloc(&st->shared, dev,
+					    0.0, NULL, false);
 		if (err)
 			goto out;
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -88,9 +88,6 @@ static void *read_thread(void *data)
 			else
 				break;
 
-			//			if (now < (offset + xts))
-			//				break;
-
 			av_init_packet(&pkt);
 
 			ret = av_read_frame(st->ic, &pkt);

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -219,7 +219,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 		re_snprintf(buf, sizeof(buf), "%d", (int)cfg->video.fps);
 		av_dict_set(&format_opts, "frame_rate", buf, 0);
 	}
-	av_dict_set(&format_opts, "camera_index", "1", 0);
 
 	ret = avformat_open_input(&st->ic, dev, input_format, &format_opts);
 	if (ret < 0) {

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -223,9 +223,9 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 	}
 	if (video && fps) {
 		re_snprintf(buf, sizeof(buf), "%d", (int)fps);
-		ret = av_dict_set(&format_opts, "frame_rate", buf, 0);
+		ret = av_dict_set(&format_opts, "framerate", buf, 0);
 		if (ret != 0) {
-			warning("avformat: av_dict_set(frame_rate) failed"
+			warning("avformat: av_dict_set(framerate) failed"
 				" (ret=%s)\n", av_err2str(ret));
 			err = ENOENT;
 			goto out;

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -206,8 +206,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 		goto out;
 
 	input_format = av_find_input_format(dev);
-	if (!input_format)
-		input_format = NULL;
 
 	ret = avformat_open_input(&st->ic, dev, input_format, NULL);
 	if (ret < 0) {

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -184,6 +184,7 @@ static int open_codec(struct stream *s, const struct AVStream *strm, int i,
 int avformat_shared_alloc(struct shared **shp, const char *dev)
 {
 	struct shared *st;
+	AVInputFormat *input_format;
 	unsigned i;
 	int err;
 	int ret;
@@ -203,8 +204,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 	err = lock_alloc(&st->lock);
 	if (err)
 		goto out;
-
-	ff_const59 AVInputFormat *input_format;
 
 	input_format = av_find_input_format(dev);
 	if (!input_format)

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -207,13 +207,8 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 	ff_const59 AVInputFormat *input_format;
 
 	input_format = av_find_input_format(dev);
-
-	if (!input_format) {
-		warning("avformat: av_find_input_format(%s) not found\n",
-			dev);
-		err = ENOENT;
-		goto out;
-	}
+	if (!input_format)
+		input_format = NULL;
 
 	ret = avformat_open_input(&st->ic, dev, input_format, NULL);
 	if (ret < 0) {

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -222,7 +222,7 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 		}
 	}
 	if (video && fps) {
-		re_snprintf(buf, sizeof(buf), "%d", (int)fps);
+		re_snprintf(buf, sizeof(buf), "%2.f", fps);
 		ret = av_dict_set(&format_opts, "framerate", buf, 0);
 		if (ret != 0) {
 			warning("avformat: av_dict_set(framerate) failed"

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -13,6 +13,7 @@
 #include <baresip.h>
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
+#include <libavdevice/avdevice.h>
 #include "mod_avformat.h"
 
 
@@ -203,7 +204,20 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 	if (err)
 		goto out;
 
-	ret = avformat_open_input(&st->ic, dev, NULL, NULL);
+	avdevice_register_all();
+
+	ff_const59 AVInputFormat *input_format;
+
+	input_format = av_find_input_format(dev);
+
+	if (!input_format) {
+		warning("avformat: av_find_input_format(%s) not found\n",
+			dev);
+		err = ENOENT;
+		goto out;
+	}
+
+	ret = avformat_open_input(&st->ic, dev, input_format, NULL);
 	if (ret < 0) {
 		warning("avformat: avformat_open_input(%s) failed (ret=%s)\n",
 			dev, av_err2str(ret));

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -204,8 +204,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev)
 	if (err)
 		goto out;
 
-	avdevice_register_all();
-
 	ff_const59 AVInputFormat *input_format;
 
 	input_format = av_find_input_format(dev);
@@ -312,6 +310,8 @@ static int module_init(void)
 	int err;
 
 	avformat_network_init();
+
+	avdevice_register_all();
 
 	err  = ausrc_register(&ausrc, baresip_ausrcl(),
 			      "avformat", avformat_audio_alloc);

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -91,6 +91,10 @@ static void *read_thread(void *data)
 			else
 				break;
 
+			if (!(st->is_realtime))
+				if (now < (offset + xts))
+					break;
+
 			av_init_packet(&pkt);
 
 			ret = av_read_frame(st->ic, &pkt);
@@ -204,6 +208,9 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 
 	st->au.idx  = -1;
 	st->vid.idx = -1;
+
+	st->is_realtime = 0==strcmp(dev, "android_camera") ||
+		0==strcmp(dev, "v4l2");
 
 	err = lock_alloc(&st->lock);
 	if (err)

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -22,7 +22,9 @@ struct shared {
 };
 
 
-int  avformat_shared_alloc(struct shared **shp, const char *dev);
+int avformat_shared_alloc(struct shared **shp, const char *dev,
+			  const double fps, const struct vidsz *size,
+			  bool video);
 void avformat_shared_set_audio(struct shared *sh, struct ausrc_st *st);
 void avformat_shared_set_video(struct shared *sh, struct vidsrc_st *st);
 

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -12,6 +12,7 @@ struct shared {
 	struct lock *lock;
 	AVFormatContext *ic;
 	pthread_t thread;
+	bool is_realtime;
 	bool run;
 
 	struct stream {

--- a/modules/avformat/module.mk
+++ b/modules/avformat/module.mk
@@ -9,6 +9,7 @@ $(MOD)_SRCS	+= avformat.c
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= video.c
 $(MOD)_LFLAGS	+= \
-	`pkg-config --libs libavformat libavcodec libswresample libavutil libavdevice libavfilter libswscale libpostproc`
+	`pkg-config --libs libavformat libavcodec libswresample \
+		libavutil libavdevice libavfilter libswscale libpostproc`
 
 include mk/mod.mk

--- a/modules/avformat/module.mk
+++ b/modules/avformat/module.mk
@@ -9,6 +9,6 @@ $(MOD)_SRCS	+= avformat.c
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= video.c
 $(MOD)_LFLAGS	+= \
-	`pkg-config --libs libavformat libavcodec libswresample libavutil`
+	`pkg-config --libs libavformat libavcodec libswresample libavutil libavdevice libavfilter libswscale libpostproc`
 
 include mk/mod.mk

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -77,7 +77,8 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 		st->shared = mem_ref(*ctx);
 	}
 	else {
-		err = avformat_shared_alloc(&st->shared, dev);
+		err = avformat_shared_alloc(&st->shared, dev,
+					    prm->fps, size, true);
 		if (err)
 			goto out;
 


### PR DESCRIPTION
Added  avdevice_register_all() and av_find_input_format() calls before avformat_open_input() call.

Added libs to module.mk needed by avdevice_register_all().