### PR TITLE
JSON initial codec state command and response

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -59,6 +59,7 @@ struct account;
 
 int account_alloc(struct account **accp, const char *sipaddr);
 int account_debug(struct re_printf *pf, const struct account *acc);
+int account_json_api(struct odict *odacc, struct odict *odcfg, const struct account *acc);
 int account_set_auth_user(struct account *acc, const char *user);
 int account_set_auth_pass(struct account *acc, const char *pass);
 int account_set_outbound(struct account *acc, const char *ob, unsigned ix);
@@ -737,6 +738,7 @@ int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_options_send(struct ua *ua, const char *uri,
 		     options_resp_h *resph, void *arg);
 int  ua_debug(struct re_printf *pf, const struct ua *ua);
+int  ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *ua);
 int  ua_print_calls(struct re_printf *pf, const struct ua *ua);
 int  ua_print_status(struct re_printf *pf, const struct ua *ua);
 int  ua_print_supported(struct re_printf *pf, const struct ua *ua);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -738,7 +738,7 @@ int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_options_send(struct ua *ua, const char *uri,
 		     options_resp_h *resph, void *arg);
 int  ua_debug(struct re_printf *pf, const struct ua *ua);
-int  ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *ua);
+int  ua_state_json_api(struct odict *od, const struct ua *ua);
 int  ua_print_calls(struct re_printf *pf, const struct ua *ua);
 int  ua_print_status(struct re_printf *pf, const struct ua *ua);
 int  ua_print_supported(struct re_printf *pf, const struct ua *ua);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -59,7 +59,8 @@ struct account;
 
 int account_alloc(struct account **accp, const char *sipaddr);
 int account_debug(struct re_printf *pf, const struct account *acc);
-int account_json_api(struct odict *odacc, struct odict *odcfg, const struct account *acc);
+int account_json_api(struct odict *odacc, struct odict *odcfg,
+		 const struct account *acc);
 int account_set_auth_user(struct account *acc, const char *user);
 int account_set_auth_pass(struct account *acc, const char *pass);
 int account_set_outbound(struct account *acc, const char *ob, unsigned ix);

--- a/modules/debug_cmd/debug_cmd.c
+++ b/modules/debug_cmd/debug_cmd.c
@@ -82,6 +82,36 @@ static int cmd_ua_debug(struct re_printf *pf, void *unused)
 }
 
 
+/**
+ * Returns the current User-Agent and general codec state.
+ * Formatted as JSON, for use with TCP / MQTT API interface.
+ *
+ * @return Current User-Agent, NULL if none
+ */
+static int cmd_api_uastate(struct re_printf *pf, void *unused)
+{
+	(void)unused;
+	int err;
+	struct odict *od = NULL;
+
+	err = odict_alloc(&od, 8);
+	if (err)
+		return err;
+
+	struct le *le;
+	for (le = list_head(uag_list()); le && !err; le = le->next) {
+		const struct ua *ua = le->data;
+
+		err |= ua_state_json_api(od, pf, ua);
+		err |= json_encode_odict(pf, od);
+
+		if (err)
+			warning("debug: failed to encode json (%m)\n", err);
+	}
+	return re_hprintf(pf, "\n");
+}
+
+
 static int cmd_play_file(struct re_printf *pf, void *arg)
 {
 	static struct play *g_play;
@@ -187,6 +217,7 @@ static const struct cmd debugcmdv[] = {
 {"timers",      0,       0, "Timer debug",            tmr_status          },
 {"uastat",     'u',      0, "UA debug",               cmd_ua_debug        },
 {"uuid",        0,       0, "Print UUID",             print_uuid          },
+{"apistate",    0,       0, "User Agent state",       cmd_api_uastate     },
 };
 
 

--- a/modules/debug_cmd/debug_cmd.c
+++ b/modules/debug_cmd/debug_cmd.c
@@ -83,10 +83,10 @@ static int cmd_ua_debug(struct re_printf *pf, void *unused)
 
 
 /**
- * Returns the current User-Agent and general codec state.
+ * Returns all the User-Agents and their general codec state.
  * Formatted as JSON, for use with TCP / MQTT API interface.
  *
- * @return Current User-Agent, NULL if none
+ * @return All User-Agents available, NULL if none
  */
 static int cmd_api_uastate(struct re_printf *pf, void *unused)
 {
@@ -102,7 +102,8 @@ static int cmd_api_uastate(struct re_printf *pf, void *unused)
 	for (le = list_head(uag_list()); le && !err; le = le->next) {
 		const struct ua *ua = le->data;
 
-		err |= ua_state_json_api(od, pf, ua);
+		err |= ua_state_json_api(od, ua);
+		/* todo: add to list */
 		err |= json_encode_odict(pf, od);
 
 		if (err)

--- a/modules/debug_cmd/debug_cmd.c
+++ b/modules/debug_cmd/debug_cmd.c
@@ -93,12 +93,12 @@ static int cmd_api_uastate(struct re_printf *pf, void *unused)
 	(void)unused;
 	int err;
 	struct odict *od = NULL;
+	struct le *le;
 
 	err = odict_alloc(&od, 8);
 	if (err)
 		return err;
 
-	struct le *le;
 	for (le = list_head(uag_list()); le && !err; le = le->next) {
 		const struct ua *ua = le->data;
 
@@ -108,6 +108,8 @@ static int cmd_api_uastate(struct re_printf *pf, void *unused)
 		if (err)
 			warning("debug: failed to encode json (%m)\n", err);
 	}
+
+	mem_deref(od);
 	return re_hprintf(pf, "\n");
 }
 

--- a/src/account.c
+++ b/src/account.c
@@ -1259,40 +1259,54 @@ int account_debug(struct re_printf *pf, const struct account *acc)
  *
  * @return 0 if success, otherwise errorcode
  */
-int account_json_api(struct odict *od, struct odict *odcfg, const struct account *acc)
+int account_json_api(struct odict *od, struct odict *odcfg,
+		const struct account *acc)
 {
 	int err = 0;
+	struct odict *obn = NULL;
+	const char *stunhost = "";
 
 	if (!acc)
 		return 0;
 
 	/* account */
 	err |= odict_entry_add(od, "aor", ODICT_STRING, acc->aor);
-	err |= odict_entry_add(od, "display_name", ODICT_STRING, acc->dispname);
+	if (acc->dispname) {
+		err |= odict_entry_add(od, "display_name", ODICT_STRING,
+				acc->dispname);
+	}
 
 	/* config */
-	err |= odict_entry_add(odcfg, "sip_nat", ODICT_STRING, account_sipnat(acc));
+	if (acc->sipnat) {
+		err |= odict_entry_add(odcfg, "sip_nat", ODICT_STRING,
+				acc->sipnat);
+	}
 
-	struct odict *obn = NULL;
 	err |= odict_alloc(&obn, 8);
 	for (size_t i=0; i<ARRAY_SIZE(acc->outboundv); i++) {
 		if (acc->outboundv[i]) {
-			err |= odict_entry_add(obn, "outbound", ODICT_STRING, acc->outboundv[i]);
+			err |= odict_entry_add(obn, "outbound", ODICT_STRING,
+					acc->outboundv[i]);
 		}
 	}
 	err |= odict_entry_add(odcfg, "sip_nat_outbound", ODICT_ARRAY, obn);
 
-	const char *stunhost = account_stun_host(acc) ? account_stun_host(acc) : "";
+	stunhost = account_stun_host(acc) ? account_stun_host(acc) : "";
 	err |= odict_entry_add(odcfg, "stun_host", ODICT_STRING, stunhost);
-	err |= odict_entry_add(odcfg, "stun_port", ODICT_INT, account_stun_port(acc));
-	err |= odict_entry_add(odcfg, "stun_user", ODICT_STRING, account_stun_user(acc));
-	const char *stunpwd = account_stun_pass(acc) != NULL ? "***" : "";
-	err |= odict_entry_add(odcfg, "stun_pass", ODICT_STRING, stunpwd);
+	err |= odict_entry_add(odcfg, "stun_port", ODICT_INT,
+			account_stun_port(acc));
+	if (acc->stun_user) {
+		err |= odict_entry_add(odcfg, "stun_user", ODICT_STRING,
+				acc->stun_user);
+	}
 
-	err |= odict_entry_add(odcfg, "answer_mode", ODICT_STRING, answermode_str(acc->answermode));
+	err |= odict_entry_add(odcfg, "answer_mode", ODICT_STRING,
+			answermode_str(acc->answermode));
 	err |= odict_entry_add(odcfg, "call_transfer", ODICT_BOOL, acc->refer);
 
-	err |= odict_entry_add(odcfg, "packet_time", ODICT_INT, account_ptime(acc));
+	err |= odict_entry_add(odcfg, "packet_time", ODICT_INT,
+			account_ptime(acc));
 
+	mem_deref(obn);
 	return err;
 }

--- a/src/account.c
+++ b/src/account.c
@@ -1241,10 +1241,58 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 		}
 		err |= re_hprintf(pf, "\n");
 	}
-	err |= re_hprintf(pf, " call_transfer:         %s\n",
+	err |= re_hprintf(pf, " call_transfer:%s\n",
 			  account_call_transfer(acc));
-	err |= re_hprintf(pf, " extra:         %s\n",
+	err |= re_hprintf(pf, " extra:        %s\n",
 			  acc->extra ? acc->extra : "none");
+
+	return err;
+}
+
+
+/**
+ * Print the account information in JSON
+ *
+ * @param od  Account dict
+ * @param odcfg  Configuration dict
+ * @param acc User-Agent account
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int account_json_api(struct odict *od, struct odict *odcfg, const struct account *acc)
+{
+	int err = 0;
+
+	if (!acc)
+		return 0;
+
+	/* account */
+	err |= odict_entry_add(od, "aor", ODICT_STRING, acc->aor);
+	err |= odict_entry_add(od, "display_name", ODICT_STRING, acc->dispname);
+
+	/* config */
+	err |= odict_entry_add(odcfg, "sip_nat", ODICT_STRING, account_sipnat(acc));
+
+	struct odict *obn = NULL;
+	err |= odict_alloc(&obn, 8);
+	for (size_t i=0; i<ARRAY_SIZE(acc->outboundv); i++) {
+		if (acc->outboundv[i]) {
+			err |= odict_entry_add(obn, "outbound", ODICT_STRING, acc->outboundv[i]);
+		}
+	}
+	err |= odict_entry_add(odcfg, "sip_nat_outbound", ODICT_ARRAY, obn);
+
+	const char *stunhost = account_stun_host(acc) ? account_stun_host(acc) : "";
+	err |= odict_entry_add(odcfg, "stun_host", ODICT_STRING, stunhost);
+	err |= odict_entry_add(odcfg, "stun_port", ODICT_INT, account_stun_port(acc));
+	err |= odict_entry_add(odcfg, "stun_user", ODICT_STRING, account_stun_user(acc));
+	const char *stunpwd = account_stun_pass(acc) != NULL ? "***" : "";
+	err |= odict_entry_add(odcfg, "stun_pass", ODICT_STRING, stunpwd);
+
+	err |= odict_entry_add(odcfg, "answer_mode", ODICT_STRING, answermode_str(acc->answermode));
+	err |= odict_entry_add(odcfg, "call_transfer", ODICT_BOOL, acc->refer);
+
+	err |= odict_entry_add(odcfg, "packet_time", ODICT_INT, account_ptime(acc));
 
 	return err;
 }

--- a/src/core.h
+++ b/src/core.h
@@ -220,6 +220,7 @@ int  reg_register(struct reg *reg, const char *reg_uri,
 void reg_unregister(struct reg *reg);
 bool reg_isok(const struct reg *reg);
 int  reg_debug(struct re_printf *pf, const struct reg *reg);
+int  reg_json_api(struct odict *od, const struct reg *reg);
 int  reg_status(struct re_printf *pf, const struct reg *reg);
 int  reg_af(const struct reg *reg);
 

--- a/src/reg.c
+++ b/src/reg.c
@@ -271,8 +271,8 @@ int reg_debug(struct re_printf *pf, const struct reg *reg)
 /**
  * Print the registration information in JSON
  *
- * @param pf  Print function
- * @param ua  Registration object
+ * @param od  Registration dict
+ * @param reg Registration object
  *
  * @return 0 if success, otherwise errorcode
  */
@@ -283,10 +283,12 @@ int reg_json_api(struct odict *od, const struct reg *reg)
 	if (!reg)
 		return 0;
 
-	err |= odict_entry_add(od, "id", ODICT_INT, reg->id);
-	err |= odict_entry_add(od, "scode", ODICT_INT, reg->scode);
-	err |= odict_entry_add(od, "srv", ODICT_STRING, reg->srv);
-	err |= odict_entry_add(od, "af", ODICT_STRING, af_name(reg->af));
+	err |= odict_entry_add(od, "id", ODICT_INT, (int64_t) reg->id);
+	err |= odict_entry_add(od, "scode", ODICT_INT, (int64_t) reg->scode);
+	if (reg->srv)
+		err |= odict_entry_add(od, "srv", ODICT_STRING, reg->srv);
+	err |= odict_entry_add(od, "ip_version", ODICT_STRING,
+			af_name(reg->af));
 
 	return err;
 }

--- a/src/reg.c
+++ b/src/reg.c
@@ -284,10 +284,12 @@ int reg_json_api(struct odict *od, const struct reg *reg)
 		return 0;
 
 	err |= odict_entry_add(od, "id", ODICT_INT, (int64_t) reg->id);
-	err |= odict_entry_add(od, "scode", ODICT_INT, (int64_t) reg->scode);
+	err |= odict_entry_add(od, "state", ODICT_BOOL, reg_isok(reg));
+	err |= odict_entry_add(od, "code", ODICT_INT, (int64_t) reg->scode);
 	if (reg->srv)
 		err |= odict_entry_add(od, "srv", ODICT_STRING, reg->srv);
-	err |= odict_entry_add(od, "ip_version", ODICT_STRING,
+
+	err |= odict_entry_add(od, "ipv", ODICT_STRING,
 			af_name(reg->af));
 
 	return err;

--- a/src/reg.c
+++ b/src/reg.c
@@ -246,7 +246,7 @@ static const char *print_scode(uint16_t scode)
  * Print the registration debug information
  *
  * @param pf  Print function
- * @param ua  Registration object
+ * @param reg Registration object
  *
  * @return 0 if success, otherwise errorcode
  */

--- a/src/reg.c
+++ b/src/reg.c
@@ -242,6 +242,14 @@ static const char *print_scode(uint16_t scode)
 }
 
 
+/**
+ * Print the registration debug information
+ *
+ * @param pf  Print function
+ * @param ua  Registration object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
 int reg_debug(struct re_printf *pf, const struct reg *reg)
 {
 	int err = 0;
@@ -255,6 +263,30 @@ int reg_debug(struct re_printf *pf, const struct reg *reg)
 			  reg->scode, print_scode(reg->scode));
 	err |= re_hprintf(pf, " srv:    %s\n", reg->srv);
 	err |= re_hprintf(pf, " af:     %s\n", af_name(reg->af));
+
+	return err;
+}
+
+
+/**
+ * Print the registration information in JSON
+ *
+ * @param pf  Print function
+ * @param ua  Registration object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int reg_json_api(struct odict *od, const struct reg *reg)
+{
+	int err = 0;
+
+	if (!reg)
+		return 0;
+
+	err |= odict_entry_add(od, "id", ODICT_INT, reg->id);
+	err |= odict_entry_add(od, "scode", ODICT_INT, reg->scode);
+	err |= odict_entry_add(od, "srv", ODICT_STRING, reg->srv);
+	err |= odict_entry_add(od, "af", ODICT_STRING, af_name(reg->af));
 
 	return err;
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -1239,6 +1239,60 @@ int ua_debug(struct re_printf *pf, const struct ua *ua)
 }
 
 
+/**
+ * Print the user-agent information in JSON
+ *
+ * @param od  User-Agent dict
+ * @param pf  Print function
+ * @param ua  User-Agent object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *ua)
+{
+	struct odict *reg = NULL;
+	struct odict *cfg = NULL;
+	struct le *le;
+	int err = 0;
+
+	if (!ua)
+		return 0;
+
+	err |= odict_alloc(&reg, 8);
+	err |= odict_alloc(&cfg, 8);
+
+	/* user-agent info */
+	err |= odict_entry_add(od, "cuser", ODICT_STRING, ua->cuser);
+
+	/* account info */
+	err |= account_json_api(od, cfg, ua->acc);
+	if (err)
+		warning("ua: failed to encode json account (%m)\n", err);
+
+	/* registration info */
+	err |= odict_entry_add(reg, "interval", ODICT_INT, ua->acc->regint);
+	err |= odict_entry_add(reg, "q_value", ODICT_DOUBLE, ua->acc->regq);
+	/* TODO: current not working */
+	err |= odict_entry_add(reg, "current", ODICT_BOOL, ua == uag_current());
+
+	for (le = ua->regl.head; le; le = le->next) {
+		/* TODO: how to get only current ua register state? */
+		err |= reg_json_api(reg, le->data);
+	}
+	if (err)
+		warning("ua: failed to encode json registration (%m)\n", err);
+
+	/* package */
+	/* TODO: this is complaining, how to build these objects? */
+	err |= odict_entry_add(od, "settings", ODICT_OBJECT, cfg);
+	err |= odict_entry_add(od, "registration", ODICT_OBJECT, reg);
+	if (err)
+		warning("ua: failed to encode json package (%m)\n", err);
+
+	return err;
+}
+
+
 /* One instance */
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1243,13 +1243,11 @@ int ua_debug(struct re_printf *pf, const struct ua *ua)
  * Print the user-agent information in JSON
  *
  * @param od  User-Agent dict
- * @param pf  Print function
  * @param ua  User-Agent object
  *
  * @return 0 if success, otherwise errorcode
  */
-int ua_state_json_api(struct odict *od, struct re_printf *pf,
-		const struct ua *ua)
+int ua_state_json_api(struct odict *od, const struct ua *ua)
 {
 	struct odict *reg = NULL;
 	struct odict *cfg = NULL;
@@ -1279,14 +1277,14 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf,
 	err |= odict_entry_add(reg, "q_value", ODICT_DOUBLE, ua->acc->regq);
 
 	for (le = ua->regl.head; le; le = le->next) {
+		struct reg *regm = le->data;
 		/* TODO: how to get only current ua register state? */
-		err |= reg_json_api(reg, le->data);
+		err |= reg_json_api(reg, regm);
 	}
 	if (err)
 		warning("ua: failed to encode json registration (%m)\n", err);
 
 	/* package */
-	/* TODO: this is complaining, how to build these objects? */
 	err |= odict_entry_add(od, "settings", ODICT_OBJECT, cfg);
 	err |= odict_entry_add(od, "registration", ODICT_OBJECT, reg);
 	if (err)

--- a/src/ua.c
+++ b/src/ua.c
@@ -1248,7 +1248,8 @@ int ua_debug(struct re_printf *pf, const struct ua *ua)
  *
  * @return 0 if success, otherwise errorcode
  */
-int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *ua)
+int ua_state_json_api(struct odict *od, struct re_printf *pf,
+		const struct ua *ua)
 {
 	struct odict *reg = NULL;
 	struct odict *cfg = NULL;
@@ -1264,7 +1265,8 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *u
 	/* user-agent info */
 	err |= odict_entry_add(od, "cuser", ODICT_STRING, ua->cuser);
 	/* TODO: 'selected_ua' not working, it's always true? */
-	err |= odict_entry_add(od, "selected_ua", ODICT_BOOL, ua == uag_current());
+	err |= odict_entry_add(od, "selected_ua", ODICT_BOOL,
+			ua == uag_current());
 
 	/* account info */
 	err |= account_json_api(od, cfg, ua->acc);
@@ -1272,7 +1274,8 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *u
 		warning("ua: failed to encode json account (%m)\n", err);
 
 	/* registration info */
-	err |= odict_entry_add(reg, "interval", ODICT_INT, ua->acc->regint);
+	err |= odict_entry_add(reg, "interval", ODICT_INT,
+			(int64_t) ua->acc->regint);
 	err |= odict_entry_add(reg, "q_value", ODICT_DOUBLE, ua->acc->regq);
 
 	for (le = ua->regl.head; le; le = le->next) {
@@ -1288,7 +1291,8 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *u
 	err |= odict_entry_add(od, "registration", ODICT_OBJECT, reg);
 	if (err)
 		warning("ua: failed to encode json package (%m)\n", err);
-
+	mem_deref(cfg);
+	mem_deref(reg);
 	return err;
 }
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1263,6 +1263,8 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *u
 
 	/* user-agent info */
 	err |= odict_entry_add(od, "cuser", ODICT_STRING, ua->cuser);
+	/* TODO: 'selected_ua' not working, it's always true? */
+	err |= odict_entry_add(od, "selected_ua", ODICT_BOOL, ua == uag_current());
 
 	/* account info */
 	err |= account_json_api(od, cfg, ua->acc);
@@ -1272,8 +1274,6 @@ int ua_state_json_api(struct odict *od, struct re_printf *pf, const struct ua *u
 	/* registration info */
 	err |= odict_entry_add(reg, "interval", ODICT_INT, ua->acc->regint);
 	err |= odict_entry_add(reg, "q_value", ODICT_DOUBLE, ua->acc->regq);
-	/* TODO: current not working */
-	err |= odict_entry_add(reg, "current", ODICT_BOOL, ua == uag_current());
 
 	for (le = ua->regl.head; le; le = le->next) {
 		/* TODO: how to get only current ua register state? */


### PR DESCRIPTION
Hi!
Thanks for answering the 'issue' #959 . "MQTT / TCP on connection client state request". 

As mentioned before in the "issue" the idea here is to have a command with a JSON-formatted response. The command could be used when you are starting an api connection to Baresip, via TCP or MQTT. Similair like how '/uastat' and '/callstat' is used today, so an external application could get up and running without a lot of parsing of those commands. The new 'response' could also be the default response on registration and call events...

I should start with an apology, I don't have a deep knowledge of C-programming. So the pull-request is a very early one, maybe @alfredh you can put me in the right direction. Please let me know if I should look up something before you give a proper response, I don't want to bother you with too trivial things..

* How memory is working and how the code i wrote is effecting that, I couldn't tell you..
* I'm probably not using 'pointers' and references in the correct way..
* I implemented a command in the debug_cmd, and I hope the placement of the other functions is ok/correct, maybe there is a better place or even in some custom module?
  * menu '/apistate' command added in debug_cmd.c
  * cmd_api_uastate added in devug_cmd.c
  * ua_state_json_api added in ua.c
  * account_json_api added in account.c
  * reg_json_api added in reg.c
* I will add some comments on specific rows, where I could not get the code to work in the way I'm thinking. There is some things that is not working in the way I think.
* This "object" only contains the user-agent, settings and account information. Call information will come later and maybe even in another function / "object". Depending how this goes.

```json
{
    "cuser":"rogersan-0x7f81ded10c30",
    "selected_ua":true,
    "aor":"sip:rogersan@domain.com",
    "display_name":"Roger San",
    "settings":{
        "sip_nat":"outbound",
        "sip_nat_outbound":[
            "sip:primary.example.com",
            "sip:secondary.example.com"
        ],
        "stun_host":"",
        "stun_port":0,
        "stun_user":"rogersan",
        "stun_pass":"***",
        "answer_mode":"manual",
        "call_transfer":true,
        "packet_time":20
    },
    "registration":{
        "interval":3697,
        "q_value":0.000000,
        "id":1,
        "scode":999,
        "af":"v4"
    }
}
```
Best regards
Roger