### PR TITLE
test: add usage of g711.so module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,13 +221,22 @@ $(BIN):	$(APP_OBJS)
 		-L$(LIBRE_SO) -lre $(LIBS) -o $@
 
 
+#
+# List of modules used by selftest
+#
+ifneq ($(STATIC),)
+TEST_MODULES :=
+else
+TEST_MODULES := g711.so
+endif
+
 .PHONY: test
 test:	$(TEST_BIN)
 	./$(TEST_BIN)
 
-$(TEST_BIN):	$(STATICLIB) $(TEST_OBJS)
+$(TEST_BIN):	$(STATICLIB) $(TEST_OBJS) $(TEST_MODULES)
 	@echo "  LD      $@"
-	$(HIDE)$(LD) $(LFLAGS) $(TEST_OBJS) \
+	$(HIDE)$(LD) $(LFLAGS) $(APP_LFLAGS) $(TEST_OBJS) \
 		-L$(LIBRE_SO) -L. \
 		-l$(PROJECT) -lre $(LIBS) $(TEST_LIBS) -o $@
 

--- a/test/call.c
+++ b/test/call.c
@@ -78,7 +78,9 @@ struct fixture {
 	f->estab_action = ACTION_RECANCEL;				\
 	f->exp_estab = 1;						\
 	f->exp_closed = 1;						\
-	mock_aucodec_register(baresip_aucodecl());			\
+	/* NOTE: See Makefile TEST_MODULES */				\
+	err = module_load(".", "g711");					\
+	TEST_ERR(err);							\
 									\
 	err = ua_alloc(&f->a.ua,					\
 		       "A <sip:a@127.0.0.1>;regint=0" prm);		\
@@ -119,7 +121,7 @@ struct fixture {
 	mem_deref(f->b.ua);			\
 	mem_deref(f->a.ua);			\
 						\
-	mock_aucodec_unregister();		\
+	module_unload("g711");			\
 						\
 	uag_event_unregister(event_handler);	\
 						\


### PR DESCRIPTION
add usage of external modules in selftest.

only add g711.so for now.

When running `make test` also g711.so will be compiled
and used by selftest.

The advantage of this is that we can get modules under test,
which can then be used by tools like valgrind.