### PR TITLE
Update call->got_offer when re-INVITE or answer to re-INVITE is received

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1409,6 +1409,8 @@ static int sipsess_offer_handler(struct mbuf **descp,
 
 	if (got_offer) {
 
+		call->got_offer = true;
+
 		/* Decode SDP Offer */
 		err = sdp_decode(call->sdp, msg->mb, true);
 		if (err) {
@@ -1435,6 +1437,8 @@ static int sipsess_answer_handler(const struct sip_msg *msg, void *arg)
 	MAGIC_CHECK(call);
 
 	debug("call: got SDP answer (%zu bytes)\n", mbuf_get_left(msg->mb));
+
+	call->got_offer = false;
 
 	if (msg_ctype_cmp(&msg->ctyp, "multipart", "mixed"))
 		(void)sdp_decode_multipart(&msg->ctyp.params, msg->mb);


### PR DESCRIPTION
I noticed that ua event CALL_REMOTE_SDP parameter has always value "offer" no matter if remote answers to re-INVITE or sends re-INVITE.  This pull request updates call->got_offer depending on if answer or offer is handled.
