### PR TITLE
Test also for /usr/lib64/libspeexdsp.so to cover Fedora/RHEL/CentOS

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -164,6 +164,7 @@ USE_SNDIO := $(shell [ -f $(SYSROOT)/include/sndio.h ] || \
 USE_STDIO := $(shell [ -f $(SYSROOT)/include/termios.h ] && echo "yes")
 HAVE_SPEEXDSP := $(shell \
 	[ -f $(SYSROOT)/local/lib/libspeexdsp$(LIB_SUFFIX) ] || \
+	[ -f $(SYSROOT)/lib64/libspeexdsp$(LIB_SUFFIX) ] || \
 	[ -f $(SYSROOT)/lib/libspeexdsp$(LIB_SUFFIX) ] || \
 	[ -f $(SYSROOT_ALT)/lib/libspeexdsp$(LIB_SUFFIX) ] && echo "yes")
 ifeq ($(HAVE_SPEEXDSP),)


### PR DESCRIPTION
On Fedora/RHEL/CentOS, 64 bit libraries on multi-arch systems end up in `/usr/lib64`, thus it would be great if this path could be honored, too.